### PR TITLE
feat: put Move button in main interface

### DIFF
--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -64,6 +64,7 @@ from engine import (
     emote,
     enter_rounds,
     exit_rounds,
+    instant_move,
     open_turn,
     say,
     submit_turn,
@@ -622,11 +623,42 @@ class CombatActionView(discord.ui.View):
         )
 
     @discord.ui.button(
+        label="Move", style=discord.ButtonStyle.primary,
+        custom_id="combat:move", row=0,
+    )
+    async def move_btn(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        """Instant move — resolves immediately outside the round queue."""
+        state, char = await _check_combat_turn(interaction)
+        if state is None:
+            return
+
+        cs = state.battlefield.combatants.get(char.character_id) if state.battlefield else None
+        if cs is not None and cs.used_move:
+            await interaction.response.send_message(
+                "You've already moved this round.", ephemeral=True
+            )
+            return
+
+        current_band = cs.range_band if cs is not None else None
+        view = DestinationSelectView(
+            action_id="move",
+            char_id=char.character_id,
+            channel_id=self.channel_id,
+            current_band=current_band,
+            instant_resolve=True,
+        )
+        await interaction.response.send_message(
+            f"**{char.name}** — choose where to move:",
+            view=view,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="Oracle", style=discord.ButtonStyle.primary,
         custom_id="combat:oracle", row=0,
     )
     async def oracle_btn(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
-        """Oracle works the same in combat as in exploration."""
+        """Oracle works the same in combat as in exploration, but is limited to 1 use per round."""
         channel_id = str(interaction.channel_id)
         state = get_session(channel_id)
         if state is None:
@@ -643,7 +675,17 @@ class CombatActionView(discord.ui.View):
                 "You don't have a character in this session.", ephemeral=True
             )
             return
-        await interaction.response.send_modal(_OracleModal(channel_id=channel_id))
+        # Check oracle use limit in ROUNDS mode
+        if state.mode == SessionMode.ROUNDS and state.battlefield:
+            cs = state.battlefield.combatants.get(char.character_id)
+            if cs is not None and cs.used_oracle:
+                await interaction.response.send_message(
+                    "You've already used Oracle this round.", ephemeral=True
+                )
+                return
+        await interaction.response.send_modal(
+            _OracleModal(channel_id=channel_id, char_id=char.character_id)
+        )
 
     @discord.ui.button(
         label="Strife ↩", style=discord.ButtonStyle.secondary,
@@ -1071,18 +1113,20 @@ class DestinationSelectView(discord.ui.View):
 
     def __init__(
         self,
-        action_id:      str,
-        char_id:        UUID,
-        channel_id:     str,
-        current_band:   RangeBand | None,
-        partial_action: CombatAction | None = None,
+        action_id:       str,
+        char_id:         UUID,
+        channel_id:      str,
+        current_band:    RangeBand | None,
+        partial_action:  CombatAction | None = None,
+        instant_resolve: bool = False,
     ):
         super().__init__(timeout=180)
-        self.action_id      = action_id
-        self.char_id        = char_id
-        self.channel_id     = channel_id
-        self.current_band   = current_band
-        self.partial_action = partial_action  # carries target_id for chained flows
+        self.action_id       = action_id
+        self.char_id         = char_id
+        self.channel_id      = channel_id
+        self.current_band    = current_band
+        self.partial_action  = partial_action   # carries target_id for chained flows
+        self.instant_resolve = instant_resolve  # True for the top-level Move button
 
         options = [
             discord.SelectOption(
@@ -1114,6 +1158,22 @@ class DestinationSelectView(discord.ui.View):
             return
 
         destination = RangeBand(interaction.data["values"][0])
+
+        if self.instant_resolve:
+            # Top-level Move button: resolve immediately without entering the turn queue.
+            state = get_session(self.channel_id)
+            result = instant_move(state, self.char_id, destination)
+            if not result.ok:
+                await interaction.response.edit_message(
+                    content=result.error, view=None
+                )
+                return
+            await save_session_async(state)
+            await interaction.response.edit_message(
+                content=f"Moved to **{destination.value.replace('_', ' ')}**.", view=None
+            )
+            await update_status(interaction.channel, state)
+            return
 
         if self.partial_action is not None:
             # Chained flow: merge destination into the partial action
@@ -1367,9 +1427,10 @@ class _SayEmoteModal(discord.ui.Modal):
 
 
 class _OracleModal(discord.ui.Modal):
-    def __init__(self, *, channel_id: str) -> None:
+    def __init__(self, *, channel_id: str, char_id: UUID | None = None) -> None:
         super().__init__(title="Oracle")
         self.channel_id = channel_id
+        self.char_id    = char_id
         self.question = discord.ui.TextInput(
             label="Question or brief interaction",
             placeholder=(
@@ -1397,6 +1458,11 @@ class _OracleModal(discord.ui.Modal):
             await interaction.response.send_message(f"{result.error}", ephemeral=True)
             return
         oracle = result.data
+        # Mark oracle used for this round (ROUNDS mode only)
+        if self.char_id is not None and state.battlefield:
+            cs = state.battlefield.combatants.get(self.char_id)
+            if cs is not None:
+                cs.used_oracle = True
         await interaction.response.send_message("Oracle submitted.", ephemeral=True)
         msg = await post_oracle_question(interaction.channel, oracle)
         oracle.message_id = msg.id

--- a/data/classes/dilettante.json
+++ b/data/classes/dilettante.json
@@ -8,5 +8,5 @@
   "primary_stat": "SVY",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "move", "charge", "affect"]
+  "combat_actions": ["attack", "charge", "affect"]
 }

--- a/data/classes/knight.json
+++ b/data/classes/knight.json
@@ -8,5 +8,5 @@
   "primary_stat": "PHY",
   "max_level": 5,
   "description": "Knights who behave dishonorably may lose access to some or all of their knightly abilities. Minor infractions may incur short penalties, however major infractions could require a knight to perform a quest of atonement to reacquire their abilities.",
-  "combat_actions": ["attack", "move", "charge", "affect"]
+  "combat_actions": ["attack", "charge", "affect"]
 }

--- a/data/classes/mage.json
+++ b/data/classes/mage.json
@@ -9,5 +9,5 @@
   "primary_stat": "RSN",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "move", "charge", "affect"]
+  "combat_actions": ["attack", "charge", "affect"]
 }

--- a/data/classes/thief.json
+++ b/data/classes/thief.json
@@ -8,5 +8,5 @@
   "primary_stat": "FNS",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "move", "charge", "poison", "affect"]
+  "combat_actions": ["attack", "charge", "poison", "affect"]
 }

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -21,7 +21,13 @@ from models import DoorState, GameState, PlayerTurnSubmission, SessionMode, Turn
 
 # Import managers and utilities from submodules
 from .character import CharacterManager
-from .combat import CombatAction, apply_condition, auto_resolve_round, initialize_battlefield
+from .combat import (
+    CombatAction,
+    apply_condition,
+    auto_resolve_round,
+    initialize_battlefield,
+    instant_move,
+)
 from .core import TurnManager
 from .data_loader import (
     ACTION_REGISTRY,
@@ -689,6 +695,7 @@ __all__ = [
     "initialize_battlefield",
     "auto_resolve_round",
     "apply_condition",
+    "instant_move",
     # Data registries (read-only, loaded from data/ at startup)
     "ACTION_REGISTRY",
     "CONDITION_REGISTRY",

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -223,6 +223,34 @@ def apply_condition(
 
 
 # ---------------------------------------------------------------------------
+# instant_move
+# ---------------------------------------------------------------------------
+
+def instant_move(state: GameState, char_id: UUID, destination: RangeBand) -> object:  # EngineResult
+    """
+    Resolve a player's Move action immediately, outside the round submission
+    queue.  The range_band update is visible to subsequent Act submissions this
+    round.  Appends a narrative line to battlefield.round_log.
+    """
+    if state.battlefield is None:
+        return _err(state, "Not in combat.")
+    cs = state.battlefield.combatants.get(char_id)
+    if cs is None:
+        return _err(state, "Not in combat.")
+    if cs.used_move:
+        return _err(state, "You've already moved this round.")
+
+    action = CombatAction(action_id="move", destination=destination)
+    log: list[str] = []
+    _hook_move_to_band(state, char_id, action, log, {})
+
+    cs.used_move = True
+    state.battlefield.round_log.extend(log)
+    state.updated_at = _now()
+    return _ok(state, "\n".join(log) if log else "Move resolved.")
+
+
+# ---------------------------------------------------------------------------
 # auto_resolve_round
 # ---------------------------------------------------------------------------
 
@@ -299,6 +327,8 @@ def auto_resolve_round(state: GameState) -> object:  # EngineResult
         cs.acted_this_round = False
         cs.skip_action      = False
         cs.movement_blocked = False
+        cs.used_move        = False
+        cs.used_oracle      = False
 
     # --- 7. Build narrative
     narrative   = "\n".join(log) if log else "The round passes without incident."

--- a/models.py
+++ b/models.py
@@ -641,6 +641,8 @@ class CombatantState:
     active_conditions: list[ActiveCondition]   = field(default_factory=list)
     skip_action:       bool                    = False
     movement_blocked:  bool                    = False
+    used_move:         bool                    = False
+    used_oracle:       bool                    = False
 
 
 @dataclass

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1546,3 +1546,127 @@ class TestHookObjectValidation:
                 raise AssertionError("Should have raised")
             except ValueError as e:
                 assert "tag" in str(e).lower()
+
+
+# ---------------------------------------------------------------------------
+# instant_move
+# ---------------------------------------------------------------------------
+
+class TestInstantMove:
+    """Tests for engine.instant_move — immediate movement outside the turn queue."""
+
+    def _make_combat_state(self):
+        """Single-character combat state at FAR_MINUS (default starting position)."""
+        from engine import add_npc, register_room
+        from models import Room
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Aldric", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        start_session(state)
+        room = Room(name="Hall", description="Stone hall.")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        add_npc(state, NPC(name="Goblin", hp_current=5, hp_max=5, defense=0, damage_dice="1d6"))
+        enter_rounds(state)
+        initialize_battlefield(state)
+        open_turn(state)
+        return state
+
+    def _char_id(self, state):
+        return next(iter(state.characters))
+
+    def test_instant_move_updates_range_band(self):
+        from engine import instant_move
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+        cs = state.battlefield.combatants[char_id]
+        assert cs.range_band == RangeBand.FAR_MINUS
+
+        result = instant_move(state, char_id, RangeBand.CLOSE_MINUS)
+        assert result.ok
+        assert cs.range_band == RangeBand.CLOSE_MINUS
+
+    def test_instant_move_sets_used_move_flag(self):
+        from engine import instant_move
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+        cs = state.battlefield.combatants[char_id]
+        assert cs.used_move is False
+
+        instant_move(state, char_id, RangeBand.CLOSE_MINUS)
+        assert cs.used_move is True
+
+    def test_instant_move_blocked_on_second_call(self):
+        from engine import instant_move
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        r1 = instant_move(state, char_id, RangeBand.CLOSE_MINUS)
+        assert r1.ok
+        r2 = instant_move(state, char_id, RangeBand.ENGAGE)
+        assert not r2.ok
+        assert "already moved" in r2.error.lower()
+
+    def test_instant_move_appends_to_round_log(self):
+        from engine import instant_move
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+        prev_log_len = len(state.battlefield.round_log)
+
+        instant_move(state, char_id, RangeBand.CLOSE_MINUS)
+        assert len(state.battlefield.round_log) > prev_log_len
+
+    def test_instant_move_blocked_by_entangled_condition(self):
+        from engine import instant_move
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+        apply_condition(state, char_id, "entangled", duration=2)
+
+        result = instant_move(state, char_id, RangeBand.CLOSE_MINUS)
+        # move_to_band fires on_move hooks which set movement_blocked;
+        # the position should not change (but instant_move still returns ok=True)
+        assert result.ok
+        cs = state.battlefield.combatants[char_id]
+        assert cs.range_band == RangeBand.FAR_MINUS
+
+    def test_used_move_reset_after_auto_resolve_round(self):
+        from engine import instant_move
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        instant_move(state, char_id, RangeBand.CLOSE_MINUS)
+        cs = state.battlefield.combatants[char_id]
+        assert cs.used_move is True
+
+        submit_turn(state, char_id, "hold", combat_action={
+            "action_id": "affect", "target_id": None, "destination": None,
+            "free_text": "hold", "weapon_id": None,
+        })
+        auto_resolve_round(state)
+        assert cs.used_move is False
+
+    def test_used_oracle_reset_after_auto_resolve_round(self):
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+        cs = state.battlefield.combatants[char_id]
+
+        cs.used_oracle = True
+
+        submit_turn(state, char_id, "hold", combat_action={
+            "action_id": "affect", "target_id": None, "destination": None,
+            "free_text": "hold", "weapon_id": None,
+        })
+        auto_resolve_round(state)
+        assert cs.used_oracle is False
+
+    def test_instant_move_fails_outside_combat(self):
+        from engine import instant_move
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Aldric", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        start_session(state)
+        fake_id = next(iter(state.characters))
+
+        result = instant_move(state, fake_id, RangeBand.ENGAGE)
+        assert not result.ok
+        assert "not in combat" in result.error.lower()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -139,7 +139,7 @@ class TestProductionDataFiles:
         assert j.primary_stat == "PHY"
         assert j.max_level == 5
         assert "attack" in j.combat_actions
-        assert "move"   in j.combat_actions
+        assert "move"   not in j.combat_actions  # Move is a top-level button, not an Act action
         assert "affect" in j.combat_actions
 
     def test_job_thief_values(self):


### PR DESCRIPTION
Move now auto-moves without waiting for turn resolution. Resolves #69

-models.py — Added used_move: bool = False and used_oracle: bool = False to CombatantState (transient flags, never persisted, reset each round like skip_action/movement_blocked)
-engine/combat.py — New instant_move() function that resolves movement immediately by reusing _hook_move_to_band, sets used_move = True, and appends to round_log. The flag reset loop in auto_resolve_round step 6 now also clears both new flags.
-engine/__init__.py — Exports instant_move.
-cogs/action_buttons.py — Three changes:
-- New Move button on CombatActionView (row 0, primary style) that checks used_move, opens DestinationSelectView with instant_resolve=True -- DestinationSelectView gains an instant_resolve parameter; when True it calls instant_move() and updates status instead of queuing a submission
-- Oracle button checks used_oracle before showing the modal; _OracleModal gains a char_id parameter and sets used_oracle = True on submit
-- _build_class_action_view now filters "move" out of the action list (Move is a top-level button, not an Act submenu action)