### PR TITLE
fix: move conditions to character/npc

### DIFF
--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -777,15 +777,13 @@ def _build_class_action_view(char, state, channel_id: str) -> discord.ui.View:
 
     # Add any condition-granted actions
     if state.battlefield:
-        cs = state.battlefield.combatants.get(char.character_id)
-        if cs:
-            from engine import CONDITION_REGISTRY
-            for cond in cs.active_conditions:
-                cond_def = CONDITION_REGISTRY.get(cond.condition_id)
-                if cond_def:
-                    for granted in cond_def.grants_actions:
-                        if granted not in action_ids:
-                            action_ids.append(granted)
+        from engine import CONDITION_REGISTRY
+        for cond in char.active_conditions:
+            cond_def = CONDITION_REGISTRY.get(cond.condition_id)
+            if cond_def:
+                for granted in cond_def.grants_actions:
+                    if granted not in action_ids:
+                        action_ids.append(granted)
 
     return ClassActionView(
         action_ids=action_ids,

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -203,14 +203,17 @@ def apply_condition(
     """
     if condition_id not in CONDITION_REGISTRY:
         return _err(state, f"Unknown condition '{condition_id}'.")
-    if state.battlefield is None:
-        return _err(state, "No active battlefield — conditions can only be applied in ROUNDS mode.")
-    cs = state.battlefield.combatants.get(target_id)
-    if cs is None:
-        return _err(state, f"Combatant {target_id} not found on battlefield.")
 
-    cs.active_conditions = [c for c in cs.active_conditions if c.condition_id != condition_id]
-    cs.active_conditions.append(ActiveCondition(
+    target_char = state.characters.get(target_id)
+    target_npc  = _find_npc(state, target_id)
+    combatant   = target_char if target_char else target_npc
+    if combatant is None:
+        return _err(state, f"Combatant {target_id} not found.")
+
+    combatant.active_conditions = [
+        c for c in combatant.active_conditions if c.condition_id != condition_id
+    ]
+    combatant.active_conditions.append(ActiveCondition(
         condition_id=condition_id,
         duration_rounds=duration,
         source_id=source_id,
@@ -416,16 +419,68 @@ def _effective_stat_mod(state: GameState, actor_id: UUID, stat: str) -> int:
     base_val = getattr(actor_char.ability_scores, stat, 0)
     base_mod = get_stat_modifier(base_val)
 
-    cs = state.battlefield.combatants.get(actor_id) if state.battlefield else None
-    if cs is None:
-        return base_mod
-
     bonus = sum(
         CONDITION_REGISTRY[c.condition_id].stat_modifiers.get(stat, 0)
-        for c in cs.active_conditions
+        for c in actor_char.active_conditions
         if c.condition_id in CONDITION_REGISTRY
     )
     return base_mod + bonus
+
+
+def _effective_defense(state: GameState, combatant_id: UUID) -> int:
+    """
+    Defense floored at 0. For Characters, .defense already includes condition
+    modifiers. For NPCs (plain int field), condition modifiers are applied here.
+    """
+    char = state.characters.get(combatant_id)
+    if char:
+        return char.defense  # already includes conditions + floor
+    npc = _find_npc(state, combatant_id)
+    if npc is None:
+        return 0
+    base = npc.defense + sum(
+        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("defense", 0)
+        for c in npc.active_conditions
+        if c.condition_id in CONDITION_REGISTRY
+    )
+    return max(0, base)
+
+
+def _effective_resistance(state: GameState, combatant_id: UUID) -> int:
+    """
+    Resistance floored at 0. For Characters, .resistance already includes
+    condition modifiers. For NPCs, condition modifiers are applied here.
+    """
+    char = state.characters.get(combatant_id)
+    if char:
+        return char.resistance  # already includes conditions + floor
+    npc = _find_npc(state, combatant_id)
+    if npc is None:
+        return 0
+    base = npc.resistance + sum(
+        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("resistance", 0)
+        for c in npc.active_conditions
+        if c.condition_id in CONDITION_REGISTRY
+    )
+    return max(0, base)
+
+
+def _effective_finesse(state: GameState, combatant_id: UUID) -> int:
+    """
+    Finesse (dodge target number) after condition stat_modifiers {"finesse": N}, floored at 0.
+    "abjuring" uses +200 so attacks need a much higher roll to hit.
+    """
+    char = state.characters.get(combatant_id)
+    npc  = _find_npc(state, combatant_id)
+    base = char.ability_scores.finesse if char else (npc.ability_scores.finesse if npc else 0)
+    combatant = char if char else npc
+    if combatant:
+        base += sum(
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("finesse", 0)
+            for c in combatant.active_conditions
+            if c.condition_id in CONDITION_REGISTRY
+        )
+    return max(0, base)
 
 
 # ---------------------------------------------------------------------------
@@ -556,13 +611,11 @@ def _hook_weapon_attack(
 
     target_char = state.characters.get(target_id)
     target_npc  = _find_npc(state, target_id)
-    if target_char:
-        target_ac = target_char.ability_scores.finesse
-    elif target_npc:
-        target_ac = target_npc.ability_scores.finesse
-    else:
+    if target_char is None and target_npc is None:
         log.append(f"{actor_name} swings at nothing.")
         return
+
+    target_ac = _effective_finesse(state, target_id)
 
     roll = random.randint(1, 10*POWER_LEVEL) + attack_bonus
     if roll < target_ac:
@@ -574,14 +627,16 @@ def _hook_weapon_attack(
     crit_bonus = roll_dice_expr(dice)["total"] if is_crit else 0
     min_damage = max(1, str_mod)
     damage = max(min_damage, base_roll + crit_bonus + str_mod)
+    mitigation = (
+        _effective_resistance(state, target_id)
+        if targets_stat == "resistance"
+        else _effective_defense(state, target_id)
+    )
+    damage = max(damage - mitigation, 0)
     if target_char:
-        mitigation = target_char.resistance if targets_stat == "resistance" else target_char.defense
-        damage = max(damage - mitigation, 0)
         target_char.hp_current = max(0, target_char.hp_current - damage)
         hp_str = f"{target_char.hp_current}/{target_char.hp_max}"
     else:
-        mitigation = target_npc.resistance if targets_stat == "resistance" else target_npc.defense
-        damage = max(damage - mitigation, 0)
         target_npc.hp_current = max(0, target_npc.hp_current - damage)
         hp_str = f"{target_npc.hp_current}/{target_npc.hp_max}"
 
@@ -658,7 +713,10 @@ def _hook_move_to_band(
     if cs is None:
         return
 
-    for active_cond in cs.active_conditions:
+    actor_char = state.characters.get(actor_id)
+    actor_npc  = _find_npc(state, actor_id)
+    combatant  = actor_char if actor_char else actor_npc
+    for active_cond in (combatant.active_conditions if combatant else []):
         cond_def = CONDITION_REGISTRY.get(active_cond.condition_id)
         if cond_def:
             move_entry = cond_def.hooks.get("on_move")
@@ -714,7 +772,11 @@ def _hook_deal_damage(
     actor_npc  = _find_npc(state, actor_id)
 
     if actor_char:
-        mitigation = actor_char.defense if damage_type == "physical" else actor_char.resistance
+        mitigation = (
+            _effective_resistance(state, actor_id)
+            if damage_type != "physical"
+            else _effective_defense(state, actor_id)
+        )
         damage = max(damage - mitigation, 0)
         actor_char.hp_current = max(0, actor_char.hp_current - damage)
         hp_str = f"{actor_char.hp_current}/{actor_char.hp_max}"
@@ -725,7 +787,11 @@ def _hook_deal_damage(
             log.append(f"{actor_name} takes {damage} {damage_type} damage and falls!")
             return
     elif actor_npc:
-        mitigation = actor_npc.defense if damage_type == "physical" else actor_npc.resistance
+        mitigation = (
+            _effective_resistance(state, actor_id)
+            if damage_type != "physical"
+            else _effective_defense(state, actor_id)
+        )
         damage = max(damage - mitigation, 0)
         actor_npc.hp_current = max(0, actor_npc.hp_current - damage)
         hp_str = f"{actor_npc.hp_current}/{actor_npc.hp_max}"
@@ -862,8 +928,11 @@ def _fire_turn_start_hooks(state: GameState, log: list[str]) -> None:
     """Fire on_turn_start hooks for all combatants before the action loop."""
     if state.battlefield is None:
         return
-    for combatant_id, cs in list(state.battlefield.combatants.items()):
-        for cond in cs.active_conditions:
+    for combatant_id in list(state.battlefield.combatants):
+        char      = state.characters.get(combatant_id)
+        npc       = _find_npc(state, combatant_id)
+        combatant = char if char else npc
+        for cond in (combatant.active_conditions if combatant else []):
             cond_def = CONDITION_REGISTRY.get(cond.condition_id)
             if cond_def:
                 entry = cond_def.hooks.get("on_turn_start")
@@ -884,9 +953,15 @@ def _tick_conditions(state: GameState, log: list[str]) -> None:
     if state.battlefield is None:
         return
 
-    for combatant_id, cs in list(state.battlefield.combatants.items()):
+    for combatant_id in list(state.battlefield.combatants):
+        char      = state.characters.get(combatant_id)
+        npc       = _find_npc(state, combatant_id)
+        combatant = char if char else npc
+        if combatant is None:
+            continue
+
         still_active: list[ActiveCondition] = []
-        for cond in cs.active_conditions:
+        for cond in combatant.active_conditions:
             cond_def = CONDITION_REGISTRY.get(cond.condition_id)
             if cond_def:
                 entry = cond_def.hooks.get("on_turn_end")
@@ -903,7 +978,7 @@ def _tick_conditions(state: GameState, log: list[str]) -> None:
                 name = _combatant_name(state, combatant_id)
                 log.append(f"{name}'s {cond_name} condition has expired.")
 
-        cs.active_conditions = still_active
+        combatant.active_conditions = still_active
 
 
 # ---------------------------------------------------------------------------

--- a/engine/session.py
+++ b/engine/session.py
@@ -86,6 +86,17 @@ class SessionManager:
         state.turn_number = resumed_at
         state.rounds_started_at_turn = None
         state.battlefield = None
+        # Expire any conditions scoped to rounds (duration_rounds is not None).
+        # Permanent conditions (duration_rounds=None) survive into exploration.
+        for char in state.characters.values():
+            char.active_conditions = [
+                c for c in char.active_conditions if c.duration_rounds is None
+            ]
+        for group in state.npc_roster.groups.values():
+            for npc in group.npcs:
+                npc.active_conditions = [
+                    c for c in npc.active_conditions if c.duration_rounds is None
+                ]
         if state.current_turn:
             state.current_turn.mode = SessionMode.EXPLORATION
             state.current_turn.turn_number = resumed_at

--- a/models.py
+++ b/models.py
@@ -20,7 +20,7 @@ from uuid import UUID, uuid4
 # CharacterClass is generated in azure_engine.py from job JSON files.
 # Import it here so the rest of the codebase can import from models as before.
 from engine.azure_engine import CharacterClass
-from engine.data_loader import ITEM_REGISTRY
+from engine.data_loader import CONDITION_REGISTRY, ITEM_REGISTRY
 from engine.item import ContainerItem, Gear, Weapon
 
 log = logging.getLogger(__name__)
@@ -183,13 +183,15 @@ class Character:
     # correct slot keys for the active ruleset when creating a character.
     equipped_slots:  dict[str, str | None] = field(default_factory=dict)
 
+    active_conditions: list[ActiveCondition] = field(default_factory=list)
+
     # Metadata
     created_at:      datetime          = field(default_factory=lambda: datetime.now(UTC))
     is_pregenerated: bool              = False
 
     @property
     def defense(self) -> int:
-        """Sum DEF from all equipped Gear items."""
+        """Sum DEF from equipped Gear items plus active condition modifiers, floored at 0."""
         total = 0
         for item_id in self.equipped_slots.values():
             if item_id is None:
@@ -197,11 +199,16 @@ class Character:
             definition = ITEM_REGISTRY.get(item_id)
             if isinstance(definition, Gear):
                 total += definition.defense
-        return total
+        total += sum(
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("defense", 0)
+            for c in self.active_conditions
+            if c.condition_id in CONDITION_REGISTRY
+        )
+        return max(0, total)
 
     @property
     def resistance(self) -> int:
-        """Sum RST from all equipped Gear items."""
+        """Sum RST from equipped Gear items plus active condition modifiers, floored at 0."""
         total = 0
         for item_id in self.equipped_slots.values():
             if item_id is None:
@@ -209,7 +216,12 @@ class Character:
             definition = ITEM_REGISTRY.get(item_id)
             if isinstance(definition, Gear):
                 total += definition.resistance
-        return total
+        total += sum(
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("resistance", 0)
+            for c in self.active_conditions
+            if c.condition_id in CONDITION_REGISTRY
+        )
+        return max(0, total)
 
     def equipped_weapon(self) -> InventoryItem | None:
         """
@@ -502,8 +514,9 @@ class NPC:
     morale:         int               = 7           # B/X morale score
     saving_throw:   int               = 15          # single value for simplicity
     hit_dice:       int               = 1           # used to compute XP on kill (hit_dice * 100)
-    status:         str               = "active"    # free-form: active/dead/fled/charmed/etc.
-    notes:          str               = ""          # DM-facing
+    status:            str               = "active"    # free-form: active/dead/fled/charmed/etc.
+    notes:             str               = ""          # DM-facing
+    active_conditions: list[ActiveCondition] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -638,7 +651,6 @@ class CombatantState:
     range_band:        RangeBand               = RangeBand.FAR_MINUS
     initiative:        int                     = 0
     acted_this_round:  bool                    = False
-    active_conditions: list[ActiveCondition]   = field(default_factory=list)
     skip_action:       bool                    = False
     movement_blocked:  bool                    = False
     used_move:         bool                    = False

--- a/persistence.py
+++ b/persistence.py
@@ -101,6 +101,9 @@ def _char_dict_from_row(row) -> dict:
         "created_at":      row["created_at"],
         "is_pregenerated": bool(row["is_pregenerated"]),
         "equipped_slots":  json.loads(equipped_slots_raw) if equipped_slots_raw else {},
+        "active_conditions": json.loads(row["active_conditions_json"])
+            if "active_conditions_json" in row.keys() and row["active_conditions_json"]  # noqa: SIM118
+            else [],
     }
     jobs_json = row["jobs_json"] if "jobs_json" in row else None # noqa: SIM401 (json, not dict)
     if jobs_json:
@@ -172,6 +175,10 @@ class Database:
         if "equipped_slots_json" not in existing:
             self._conn.execute(
                 "ALTER TABLE characters ADD COLUMN equipped_slots_json TEXT"
+            )
+        if "active_conditions_json" not in existing:
+            self._conn.execute(
+                "ALTER TABLE characters ADD COLUMN active_conditions_json TEXT"
             )
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS session_characters (
@@ -280,8 +287,9 @@ class Database:
                 experience, ability_scores_json, hp_max, hp_current,
                 movement_speed, saving_throws_json, status,
                 status_notes, inventory_json, gold,
-                created_at, is_pregenerated, updated_at, equipped_slots_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, is_pregenerated, updated_at, equipped_slots_json,
+                active_conditions_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(character_id) DO UPDATE SET
                 owner_id = excluded.owner_id,
                 name = excluded.name,
@@ -300,7 +308,8 @@ class Database:
                 gold = excluded.gold,
                 is_pregenerated = excluded.is_pregenerated,
                 updated_at = excluded.updated_at,
-                equipped_slots_json = excluded.equipped_slots_json
+                equipped_slots_json = excluded.equipped_slots_json,
+                active_conditions_json = excluded.active_conditions_json
             """,
             (
                 char_data["character_id"],
@@ -323,6 +332,7 @@ class Database:
                 1 if char_data["is_pregenerated"] else 0,
                 _now_iso(),
                 json.dumps(char_data["equipped_slots"]),
+                json.dumps(char_data["active_conditions"]),
             ),
         )
         self._conn.commit()

--- a/serialization.py
+++ b/serialization.py
@@ -122,9 +122,10 @@ def serialize_character(c: Character) -> dict:
         "status_notes":    c.status_notes,
         "inventory":       [serialize_inventory_item(i) for i in c.inventory],
         "gold":            c.gold,
-        "equipped_slots":  c.equipped_slots,  # dict[str, str|None] — no special encoding needed
-        "created_at":      _dt(c.created_at),
-        "is_pregenerated": c.is_pregenerated,
+        "equipped_slots":   c.equipped_slots,  # dict[str, str|None] — no special encoding needed
+        "created_at":       _dt(c.created_at),
+        "is_pregenerated":  c.is_pregenerated,
+        "active_conditions": [serialize_active_condition(cond) for cond in c.active_conditions],
     }
 
 
@@ -223,8 +224,9 @@ def serialize_npc(n: NPC) -> dict:
         "morale":         n.morale,
         "saving_throw":   n.saving_throw,
         "hit_dice":       n.hit_dice,
-        "status":         n.status,
-        "notes":          n.notes,
+        "status":            n.status,
+        "notes":             n.notes,
+        "active_conditions": [serialize_active_condition(cond) for cond in n.active_conditions],
     }
 
 
@@ -280,7 +282,6 @@ def serialize_combatant_state(cs: CombatantState) -> dict:
         "range_band":        _enum(cs.range_band),
         "initiative":        cs.initiative,
         "acted_this_round":  cs.acted_this_round,
-        "active_conditions": [serialize_active_condition(c) for c in cs.active_conditions],
     }
 
 
@@ -431,6 +432,7 @@ def deserialize_character(d: dict) -> Character:
         equipped_slots=merged_slots,
         created_at=_load_dt(d["created_at"]),
         is_pregenerated=d["is_pregenerated"],
+        active_conditions=[deserialize_active_condition(c) for c in d.get("active_conditions", [])],
     )
 
 
@@ -510,6 +512,7 @@ def deserialize_npc(d: dict) -> NPC:
         hit_dice=d.get("hit_dice", 1),
         status=d["status"],
         notes=d["notes"],
+        active_conditions=[deserialize_active_condition(c) for c in d.get("active_conditions", [])],
     )
 
 
@@ -568,9 +571,6 @@ def deserialize_combatant_state(d: dict) -> CombatantState:
         range_band=RangeBand(d["range_band"]),
         initiative=d.get("initiative", 0),
         acted_this_round=d.get("acted_this_round", False),
-        active_conditions=[
-            deserialize_active_condition(c) for c in d.get("active_conditions", [])
-        ],
     )
 
 

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -178,6 +178,20 @@ class TestInitializeBattlefield:
         exit_rounds(state)
         assert state.battlefield is None
 
+    def test_exit_rounds_expires_round_conditions_keeps_permanent(self):
+        from models import ActiveCondition
+        state = _make_state_with_npc()
+        char = list(state.characters.values())[0]
+        char.active_conditions = [
+            ActiveCondition(condition_id="poisoned", duration_rounds=2),   # round-scoped
+            ActiveCondition(condition_id="strengthened", duration_rounds=None),  # permanent
+        ]
+        enter_rounds(state)
+        exit_rounds(state)
+        remaining = [c.condition_id for c in char.active_conditions]
+        assert "poisoned" not in remaining
+        assert "strengthened" in remaining
+
     def test_dead_char_excluded(self):
         state = _make_state_with_npc()
         char = list(state.characters.values())[0]
@@ -564,12 +578,14 @@ class TestApplyCondition:
         assert not result.ok
         assert "Unknown condition" in result.error
 
-    def test_apply_outside_rounds_fails(self):
+    def test_apply_outside_rounds_succeeds(self):
+        # Conditions now live on the character, so they can be applied outside combat.
         state = _make_state_with_npc()
-        # Don't enter rounds — no battlefield
         char_id = list(state.characters.keys())[0]
         result = apply_condition(state, char_id, "poisoned", duration=3)
-        assert not result.ok
+        assert result.ok
+        char = state.characters[char_id]
+        assert any(c.condition_id == "poisoned" for c in char.active_conditions)
 
     def test_apply_to_unknown_combatant_fails(self):
         state = _make_state_with_npc()
@@ -597,8 +613,8 @@ class TestApplyCondition:
 
         result = apply_condition(state, char_id, "slowed", duration=2)
         assert result.ok
-        cs = state.battlefield.combatants[char_id]
-        assert any(c.condition_id == "slowed" for c in cs.active_conditions)
+        char = state.characters[char_id]
+        assert any(c.condition_id == "slowed" for c in char.active_conditions)
         del CONDITION_REGISTRY["slowed"]
 
     def test_reapply_refreshes_duration(self):
@@ -613,8 +629,8 @@ class TestApplyCondition:
 
         apply_condition(state, char_id, "burning", duration=1)
         apply_condition(state, char_id, "burning", duration=5)
-        cs = state.battlefield.combatants[char_id]
-        conds = [c for c in cs.active_conditions if c.condition_id == "burning"]
+        char = state.characters[char_id]
+        conds = [c for c in char.active_conditions if c.condition_id == "burning"]
         assert len(conds) == 1
         assert conds[0].duration_rounds == 5
         del CONDITION_REGISTRY["burning"]
@@ -630,33 +646,33 @@ class TestTickConditions:
         state = _make_state_with_npc()
         enter_rounds(state)
         char_id = list(state.characters.keys())[0]
-        cs = state.battlefield.combatants[char_id]
-        cs.active_conditions = [ActiveCondition(condition_id="x", duration_rounds=3)]
+        char = state.characters[char_id]
+        char.active_conditions = [ActiveCondition(condition_id="x", duration_rounds=3)]
 
         _tick_conditions(state, [])
-        assert cs.active_conditions[0].duration_rounds == 2
+        assert char.active_conditions[0].duration_rounds == 2
 
     def test_condition_expires_at_zero(self):
         state = _make_state_with_npc()
         enter_rounds(state)
         char_id = list(state.characters.keys())[0]
-        cs = state.battlefield.combatants[char_id]
-        cs.active_conditions = [ActiveCondition(condition_id="x", duration_rounds=1)]
+        char = state.characters[char_id]
+        char.active_conditions = [ActiveCondition(condition_id="x", duration_rounds=1)]
 
         log: list[str] = []
         _tick_conditions(state, log)
-        assert cs.active_conditions == []
+        assert char.active_conditions == []
 
     def test_permanent_condition_never_expires(self):
         state = _make_state_with_npc()
         enter_rounds(state)
         char_id = list(state.characters.keys())[0]
-        cs = state.battlefield.combatants[char_id]
-        cs.active_conditions = [ActiveCondition(condition_id="x", duration_rounds=None)]
+        char = state.characters[char_id]
+        char.active_conditions = [ActiveCondition(condition_id="x", duration_rounds=None)]
 
         for _ in range(10):
             _tick_conditions(state, [])
-        assert len(cs.active_conditions) == 1
+        assert len(char.active_conditions) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -847,8 +863,8 @@ class TestConditions:
         state, char_id, _ = self._state_in_rounds()
         result = apply_condition(state, char_id, "poisoned", duration=3)
         assert result.ok
-        cs = state.battlefield.combatants[char_id]
-        assert any(c.condition_id == "poisoned" for c in cs.active_conditions)
+        char = state.characters[char_id]
+        assert any(c.condition_id == "poisoned" for c in char.active_conditions)
 
     def test_apply_condition_message_contains_label(self):
         state, char_id, _ = self._state_in_rounds()
@@ -894,8 +910,8 @@ class TestConditions:
         from engine.combat import _tick_conditions
         _tick_conditions(state, [])   # round 1 — duration becomes 1
         _tick_conditions(state, [])   # round 2 — expires
-        cs = state.battlefield.combatants[char_id]
-        assert not any(c.condition_id == "poisoned" for c in cs.active_conditions)
+        char = state.characters[char_id]
+        assert not any(c.condition_id == "poisoned" for c in char.active_conditions)
 
     # ------------------------------------------------------------------
     # Stunned — skip_action for one round
@@ -1089,9 +1105,7 @@ class TestPoisonAction:
         )]
         result = auto_resolve_round(state)
         assert result.ok
-        npc_cs = state.battlefield.combatants.get(npc.npc_id)
-        assert npc_cs is not None
-        assert any(c.condition_id == "poisoned" for c in npc_cs.active_conditions)
+        assert any(c.condition_id == "poisoned" for c in npc.active_conditions)
 
     def test_poison_works_at_any_range(self):
         """Thief at FAR_MINUS, guard at FAR_PLUS — should still apply."""
@@ -1118,9 +1132,7 @@ class TestPoisonAction:
             is_latest=True, combat_action=action.to_dict(),
         )]
         auto_resolve_round(state)
-        npc_cs = state.battlefield.combatants.get(npc.npc_id)
-        assert npc_cs is not None
-        cond = next(c for c in npc_cs.active_conditions if c.condition_id == "poisoned")
+        cond = next(c for c in npc.active_conditions if c.condition_id == "poisoned")
         assert cond.duration_rounds == 2   # started at 3, ticked once
         assert npc.hp_current < 20         # took poison damage this round
 
@@ -1276,9 +1288,8 @@ class TestParameterizedHooks:
             {"tag": "apply_condition", "condition": "stunned", "duration": 2},
             state, char_id, action, log,
         )
-        npc_cs = state.battlefield.combatants[npc.npc_id]
-        assert any(c.condition_id == "stunned" for c in npc_cs.active_conditions)
-        stunned = next(c for c in npc_cs.active_conditions if c.condition_id == "stunned")
+        assert any(c.condition_id == "stunned" for c in npc.active_conditions)
+        stunned = next(c for c in npc.active_conditions if c.condition_id == "stunned")
         assert stunned.duration_rounds == 2
 
     def test_apply_condition_hook_missing_condition_param_logs_error(self):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -366,3 +366,45 @@ class TestDualPathCoherency:
             assert final.experience == 2000
         finally:
             session_cache._sessions.pop("ch1", None)
+
+
+# ---------------------------------------------------------------------------
+# active_conditions round-trip
+# ---------------------------------------------------------------------------
+
+class TestActiveConditionsPersistence:
+    def test_character_active_conditions_round_trip(self, db):
+        """active_conditions survive save → load via the characters table."""
+        from engine import apply_condition, start_session
+        from engine.azure_engine import CharacterClass
+        from models import GameState, Party
+
+        s = GameState(platform_channel_id="ch99", dm_user_id="dm")
+        s.party = Party(name="P")
+        create_character(s, "Tester", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        start_session(s)
+        char = next(iter(s.characters.values()))
+
+        # Apply a condition directly (outside combat — now allowed)
+        apply_condition(s, char.character_id, "poisoned", duration=3)
+        assert len(char.active_conditions) == 1
+
+        db.save_character(char)
+        reloaded = db.load_character(str(char.character_id))
+        assert len(reloaded.active_conditions) == 1
+        assert reloaded.active_conditions[0].condition_id == "poisoned"
+        assert reloaded.active_conditions[0].duration_rounds == 3
+
+    def test_character_conditions_empty_by_default(self, db):
+        """Characters without conditions save and reload cleanly."""
+        from engine.azure_engine import CharacterClass
+        from models import GameState, Party
+
+        s = GameState(platform_channel_id="ch100", dm_user_id="dm")
+        s.party = Party(name="P")
+        create_character(s, "Clean", CharacterClass.MAGE, "Pack A", owner_id="u2")
+        char = next(iter(s.characters.values()))
+
+        db.save_character(char)
+        reloaded = db.load_character(str(char.character_id))
+        assert reloaded.active_conditions == []

--- a/webui/app.py
+++ b/webui/app.py
@@ -924,12 +924,14 @@ async def route_combatant_removecondition(
         cid = UUID(combatant_id)
     except ValueError as e:
         return _respond(channel_id, error=str(e), view_room_id=view_room_id)
-    cs = state.battlefield.combatants.get(cid)
-    if cs is None:
-        return _respond(channel_id, error="Combatant not on battlefield.", view_room_id=view_room_id)
-    before = len(cs.active_conditions)
-    cs.active_conditions = [c for c in cs.active_conditions if c.condition_id != condition_id]
-    if len(cs.active_conditions) == before:
+    char      = state.characters.get(cid)
+    npc       = next((n for g in state.npc_roster.groups.values() for n in g.npcs if n.npc_id == cid), None)
+    combatant = char if char else npc
+    if combatant is None:
+        return _respond(channel_id, error="Combatant not found.", view_room_id=view_room_id)
+    before = len(combatant.active_conditions)
+    combatant.active_conditions = [c for c in combatant.active_conditions if c.condition_id != condition_id]
+    if len(combatant.active_conditions) == before:
         return _respond(channel_id, error=f"Condition '{condition_id}' not found.", view_room_id=view_room_id)
     await save_session_async(state)
     return _respond(channel_id, view_room_id=view_room_id)

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -606,8 +606,12 @@ def _combat_subpanel(
 
     # --- Active conditions with remove buttons
     from engine.data_loader import CONDITION_REGISTRY
+    cid_uuid_for_cond = UUID(combatant_id) if not isinstance(combatant_id, UUID) else combatant_id
+    _cond_char = state.characters.get(cid_uuid_for_cond)
+    _cond_npc  = next((n for g in state.npc_roster.groups.values() for n in g.npcs if n.npc_id == cid_uuid_for_cond), None)
+    _cond_owner = _cond_char if _cond_char else _cond_npc
     cond_chips = ""
-    for cond in cs.active_conditions:
+    for cond in (_cond_owner.active_conditions if _cond_owner else []):
         cond_def = CONDITION_REGISTRY.get(cond.condition_id)
         label = cond_def.label if cond_def else cond.condition_id
         dur = f" {cond.duration_rounds}r" if cond.duration_rounds is not None else " ∞"


### PR DESCRIPTION
Resolves #70
Permanent status conditions are now possible (duration_rounds=0). activeCombatant loses the conditions list, Chracter and NPC in models.py gain lists of active conditions (defense and resistance now sum stat_modifiers inline and floor at 0). NPCs still don't incorporate status conditions (OK for now, they don't have permanent conditions)