### PR TITLE
feat: Abscond action and condition

### DIFF
--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -687,42 +687,6 @@ class CombatActionView(discord.ui.View):
             _OracleModal(channel_id=channel_id, char_id=char.character_id)
         )
 
-    @discord.ui.button(
-        label="Strife ↩", style=discord.ButtonStyle.secondary,
-        custom_id="combat:strife_end", row=0,
-    )
-    async def end_strife_btn(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
-        """End combat — DM or party leader only."""
-        channel_id = str(interaction.channel_id)
-        state = get_session(channel_id)
-        if state is None:
-            await interaction.response.send_message(
-                "No active session in this channel.", ephemeral=True
-            )
-            return
-        user_id = str(interaction.user.id)
-        char = _find_character(state, user_id)
-        is_dm = state.dm_user_id == user_id
-        is_leader = (
-            char is not None
-            and state.party is not None
-            and state.party.leader_id == char.character_id
-        )
-        if not (is_dm or is_leader):
-            await interaction.response.send_message(
-                "Only the DM or party leader can end combat.", ephemeral=True
-            )
-            return
-        result = exit_rounds(state)
-        if not result.ok:
-            await interaction.response.send_message(f"{result.error}", ephemeral=True)
-            return
-        if state.current_turn is None or state.current_turn.status != TurnStatus.OPEN:
-            open_turn(state)
-        narrative = "Combat ended — returning to exploration."
-        await interaction.response.send_message(narrative, ephemeral=True)
-        await repost_status(interaction.channel, state, narrative=narrative)
-
     # row 1 ----------------------------------------------------------------
 
     @discord.ui.button(

--- a/data/actions/abscond.json
+++ b/data/actions/abscond.json
@@ -1,0 +1,11 @@
+{
+  "action_id": "abscond",
+  "label": "Abscond",
+  "button_style": "secondary",
+  "action_type": "combat",
+  "description": "Attempt to flee combat. Roll 1d1000 + Finesse vs 500 + highest enemy Finesse. Each prior attempt this combat eases the roll.",
+  "requires_target": false,
+  "requires_destination": false,
+  "range_requirement": [],
+  "effect_tags": ["abscond_roll"]
+}

--- a/data/classes/dilettante.json
+++ b/data/classes/dilettante.json
@@ -8,5 +8,5 @@
   "primary_stat": "SVY",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "charge", "affect"]
+  "combat_actions": ["attack", "charge", "affect", "abscond"]
 }

--- a/data/classes/knight.json
+++ b/data/classes/knight.json
@@ -8,5 +8,5 @@
   "primary_stat": "PHY",
   "max_level": 5,
   "description": "Knights who behave dishonorably may lose access to some or all of their knightly abilities. Minor infractions may incur short penalties, however major infractions could require a knight to perform a quest of atonement to reacquire their abilities.",
-  "combat_actions": ["attack", "charge", "affect"]
+  "combat_actions": ["attack", "charge", "affect", "abscond"]
 }

--- a/data/classes/mage.json
+++ b/data/classes/mage.json
@@ -9,5 +9,5 @@
   "primary_stat": "RSN",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "charge", "affect"]
+  "combat_actions": ["attack", "charge", "affect", "abscond"]
 }

--- a/data/classes/thief.json
+++ b/data/classes/thief.json
@@ -8,5 +8,5 @@
   "primary_stat": "FNS",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "charge", "poison", "affect"]
+  "combat_actions": ["attack", "charge", "poison", "affect", "abscond"]
 }

--- a/data/conditions/absconding.json
+++ b/data/conditions/absconding.json
@@ -1,0 +1,11 @@
+{
+  "condition_id": "absconding",
+  "label": "Absconding",
+  "duration_type": "rounds",
+  "stackable": true,
+  "hooks": {},
+  "stat_modifiers": {
+    "abscond_bonus": 100
+  },
+  "grants_actions": []
+}

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -210,6 +210,19 @@ def apply_condition(
     if combatant is None:
         return _err(state, f"Combatant {target_id} not found.")
 
+    cond_def    = CONDITION_REGISTRY[condition_id]
+    target_name = _combatant_name(state, target_id)
+
+    # Stackable conditions accumulate stacks rather than being replaced.
+    if cond_def.stackable:
+        existing = next(
+            (c for c in combatant.active_conditions if c.condition_id == condition_id), None
+        )
+        if existing is not None:
+            existing.stacks += 1
+            state.updated_at = _now()
+            return _ok(state, f"{target_name} is now {cond_def.label} ×{existing.stacks}.")
+
     combatant.active_conditions = [
         c for c in combatant.active_conditions if c.condition_id != condition_id
     ]
@@ -218,9 +231,6 @@ def apply_condition(
         duration_rounds=duration,
         source_id=source_id,
     ))
-
-    cond_def    = CONDITION_REGISTRY[condition_id]
-    target_name = _combatant_name(state, target_id)
     state.updated_at = _now()
     return _ok(state, f"{target_name} is now {cond_def.label}.")
 
@@ -337,6 +347,12 @@ def auto_resolve_round(state: GameState) -> object:  # EngineResult
     narrative   = "\n".join(log) if log else "The round passes without incident."
     bf.round_log = log[:]
     state.updated_at = _now()
+
+    # If Abscond succeeded this round, exit combat now (after all actions resolved).
+    if bf.abscond_succeeded:
+        from engine.session import SessionManager  # local import avoids circular dep
+        SessionManager().exit_rounds(state)
+
     return _ok(state, narrative)
 
 
@@ -420,7 +436,7 @@ def _effective_stat_mod(state: GameState, actor_id: UUID, stat: str) -> int:
     base_mod = get_stat_modifier(base_val)
 
     bonus = sum(
-        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get(stat, 0)
+        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get(stat, 0) * c.stacks
         for c in actor_char.active_conditions
         if c.condition_id in CONDITION_REGISTRY
     )
@@ -439,7 +455,7 @@ def _effective_defense(state: GameState, combatant_id: UUID) -> int:
     if npc is None:
         return 0
     base = npc.defense + sum(
-        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("defense", 0)
+        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("defense", 0) * c.stacks
         for c in npc.active_conditions
         if c.condition_id in CONDITION_REGISTRY
     )
@@ -458,7 +474,7 @@ def _effective_resistance(state: GameState, combatant_id: UUID) -> int:
     if npc is None:
         return 0
     base = npc.resistance + sum(
-        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("resistance", 0)
+        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("resistance", 0) * c.stacks
         for c in npc.active_conditions
         if c.condition_id in CONDITION_REGISTRY
     )
@@ -476,7 +492,7 @@ def _effective_finesse(state: GameState, combatant_id: UUID) -> int:
     combatant = char if char else npc
     if combatant:
         base += sum(
-            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("finesse", 0)
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("finesse", 0) * c.stacks
             for c in combatant.active_conditions
             if c.condition_id in CONDITION_REGISTRY
         )
@@ -895,6 +911,80 @@ def _hook_block_movement(
         log.append(f"{_combatant_name(state, actor_id)} is entangled and cannot move!")
 
 
+def _hook_abscond_roll(
+    state:    GameState,
+    actor_id: UUID,
+    action:   CombatAction | None,
+    log:      list[str],
+    params:   dict,
+) -> None:
+    """
+    Flee attempt: 1d1000 + Finesse vs 500 + highest enemy Finesse.
+    Difficulty reduced by the actor's accumulated 'abscond_bonus' condition modifier.
+    Enemies at ENGAGE range block escape entirely.
+    Applies the stacking 'absconding' condition to all player combatants on every
+    attempt (win or lose), so each subsequent try gets easier.
+    Sets bf.abscond_succeeded = True on success; auto_resolve_round calls exit_rounds.
+
+    params: (none)
+    """
+    bf = state.battlefield
+    if bf is None:
+        return
+
+    actor_name = _combatant_name(state, actor_id)
+
+    # Positional block: any enemy at ENGAGE prevents escape
+    for cid, cs in bf.combatants.items():
+        if not cs.is_player and cs.range_band == RangeBand.ENGAGE:
+            npc = _find_npc(state, cid)
+            blocker = npc.name if npc else "An enemy"
+            log.append(f"{actor_name} tries to flee but {blocker} is blocking the way!")
+            return
+
+    # Roll
+    roll    = random.randint(1, 1000)
+    finesse = _effective_finesse(state, actor_id)
+    total   = roll + finesse
+
+    # Threshold: 500 + highest enemy Finesse − accumulated abscond_bonus
+    enemy_finesse = max(
+        (npc.ability_scores.finesse
+         for cid2, cs2 in bf.combatants.items()
+         if not cs2.is_player
+         for npc in [_find_npc(state, cid2)]
+         if npc is not None),
+        default=0,
+    )
+    actor_char = state.characters.get(actor_id)
+    bonus = 0
+    if actor_char:
+        bonus = sum(
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("abscond_bonus", 0) * c.stacks
+            for c in actor_char.active_conditions
+            if c.condition_id in CONDITION_REGISTRY
+        )
+    threshold = max(0, 500 + enemy_finesse - bonus)
+
+    # Apply stacking absconding condition to all allies (before logging outcome)
+    for cid3, cs3 in bf.combatants.items():
+        if cs3.is_player:
+            apply_condition(state, cid3, "absconding", duration=999)
+
+    # Outcome
+    if total >= threshold:
+        log.append(
+            f"{actor_name} rolls {roll} + {finesse} = **{total}** vs {threshold} — "
+            f"the party flees!"
+        )
+        bf.abscond_succeeded = True
+    else:
+        log.append(
+            f"{actor_name} rolls {roll} + {finesse} = {total} vs {threshold} — "
+            f"failed to abscond."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Hook registry
 # ---------------------------------------------------------------------------
@@ -917,6 +1007,8 @@ _HOOK_DISPATCH: dict[str, object] = {
     "apply_condition": _hook_apply_condition,
     "deal_damage":     _hook_deal_damage,
     "skip_action":     _hook_skip_action,
+    # Flee
+    "abscond_roll":    _hook_abscond_roll,
 }
 
 

--- a/engine/data_loader.py
+++ b/engine/data_loader.py
@@ -136,6 +136,7 @@ class ConditionDef:
     hooks:          dict[str, HookEntry] = field(default_factory=dict)
     stat_modifiers: dict[str, int]       = field(default_factory=dict)
     grants_actions: list[str]            = field(default_factory=list)
+    stackable:      bool                 = False
 
 
 @dataclass
@@ -242,7 +243,7 @@ _SKILL_REQUIRED = {
 }
 
 _VALID_BUTTON_STYLES  = {"primary", "secondary", "danger", "success"}
-_VALID_ACTION_TYPES   = {"attack", "move", "affect"}
+_VALID_ACTION_TYPES   = {"attack", "move", "affect", "combat"}
 _VALID_DURATION_TYPES = {"rounds", "permanent"}
 _VALID_HOOK_NAMES     = {
     "on_turn_start", "on_turn_end", "on_attack", "on_hit",
@@ -398,6 +399,7 @@ def _load_condition(path: Path) -> ConditionDef:
         hooks=hooks,
         stat_modifiers=dict(data.get("stat_modifiers", {})),
         grants_actions=list(data.get("grants_actions", [])),
+        stackable=bool(data.get("stackable", False)),
     )
 
 

--- a/models.py
+++ b/models.py
@@ -200,7 +200,7 @@ class Character:
             if isinstance(definition, Gear):
                 total += definition.defense
         total += sum(
-            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("defense", 0)
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("defense", 0) * c.stacks
             for c in self.active_conditions
             if c.condition_id in CONDITION_REGISTRY
         )
@@ -217,7 +217,7 @@ class Character:
             if isinstance(definition, Gear):
                 total += definition.resistance
         total += sum(
-            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("resistance", 0)
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("resistance", 0) * c.stacks
             for c in self.active_conditions
             if c.condition_id in CONDITION_REGISTRY
         )
@@ -628,9 +628,10 @@ class ActiveCondition:
     until explicitly removed).  source_id is the combatant that applied it,
     if any (used for some condition-removal rules).
     """
-    condition_id:    str            = ""
-    duration_rounds: int | None  = None
+    condition_id:    str         = ""
+    duration_rounds: int | None = None
     source_id:       UUID | None = None
+    stacks:          int         = 1
 
 
 @dataclass
@@ -668,8 +669,9 @@ class CombatBattlefield:
     round_log accumulates a plain-text narrative for each auto-resolved
     action within the current round.
     """
-    combatants: dict[UUID, CombatantState]  = field(default_factory=dict)
-    round_log:  list[str]                   = field(default_factory=list)
+    combatants:        dict[UUID, CombatantState] = field(default_factory=dict)
+    round_log:         list[str]                  = field(default_factory=list)
+    abscond_succeeded: bool                       = False
 
 
 @dataclass

--- a/serialization.py
+++ b/serialization.py
@@ -272,6 +272,7 @@ def serialize_active_condition(c: ActiveCondition) -> dict:
         "condition_id":    c.condition_id,
         "duration_rounds": c.duration_rounds,
         "source_id":       _uuid(c.source_id),
+        "stacks":          c.stacks,
     }
 
 
@@ -561,6 +562,7 @@ def deserialize_active_condition(d: dict) -> ActiveCondition:
         condition_id=d["condition_id"],
         duration_rounds=d.get("duration_rounds"),
         source_id=_load_uuid(d.get("source_id")),
+        stacks=d.get("stacks", 1),
     )
 
 

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1681,3 +1681,186 @@ class TestInstantMove:
         result = instant_move(state, fake_id, RangeBand.ENGAGE)
         assert not result.ok
         assert "not in combat" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestAbscondRoll
+# ---------------------------------------------------------------------------
+
+class TestAbscondRoll:
+    """Tests for _hook_abscond_roll and stacking absconding condition."""
+
+    def _make_combat_state(self):
+        """One player vs one NPC at FAR_PLUS (default), player at FAR_MINUS."""
+        from engine import add_npc, register_room
+        from models import Room
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Aldric", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        start_session(state)
+        room = Room(name="Hall", description="Stone hall.")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        add_npc(state, NPC(name="Goblin", hp_current=5, hp_max=5, defense=0, damage_dice="1d6"))
+        enter_rounds(state)
+        open_turn(state)
+        return state
+
+    def _char_id(self, state):
+        return next(iter(state.characters.keys()))
+
+    def _npc(self, state):
+        for g in state.npc_roster.groups.values():
+            for n in g.npcs:
+                return n
+
+    def test_blocked_by_enemy_at_engage(self):
+        """Enemy at ENGAGE prevents Abscond regardless of roll."""
+        from unittest.mock import patch
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+        npc = self._npc(state)
+
+        # Move enemy to ENGAGE
+        cs_npc = state.battlefield.combatants[npc.npc_id]
+        cs_npc.range_band = RangeBand.ENGAGE
+
+        with patch("engine.combat.random.randint", return_value=1000):
+            submit_turn(state, char_id, "Abscond", combat_action={
+                "action_id": "abscond", "target_id": None, "destination": None,
+                "free_text": None, "weapon_id": None,
+            })
+            auto_resolve_round(state)
+
+        # Combat should NOT have ended
+        assert state.battlefield is not None
+        assert not state.battlefield.abscond_succeeded
+
+    def test_low_roll_fails(self):
+        """Roll of 1 + low finesse should not meet threshold."""
+        from unittest.mock import patch
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        with patch("engine.combat.random.randint", return_value=1):
+            submit_turn(state, char_id, "Abscond", combat_action={
+                "action_id": "abscond", "target_id": None, "destination": None,
+                "free_text": None, "weapon_id": None,
+            })
+            auto_resolve_round(state)
+
+        # State should still be ROUNDS (auto_resolve_round did not exit)
+        from models import SessionMode
+        assert state.mode == SessionMode.ROUNDS
+
+    def test_high_roll_succeeds_and_exits_combat(self):
+        """Roll of 1000 should always beat threshold; combat ends afterward."""
+        from unittest.mock import patch
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        with patch("engine.combat.random.randint", return_value=1000):
+            submit_turn(state, char_id, "Abscond", combat_action={
+                "action_id": "abscond", "target_id": None, "destination": None,
+                "free_text": None, "weapon_id": None,
+            })
+            auto_resolve_round(state)
+
+        from models import SessionMode
+        assert state.mode == SessionMode.EXPLORATION
+        assert state.battlefield is None
+
+    def test_condition_applied_on_failure(self):
+        """absconding condition is applied to all allies even on a failed roll."""
+        from unittest.mock import patch
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        with patch("engine.combat.random.randint", return_value=1):
+            submit_turn(state, char_id, "Abscond", combat_action={
+                "action_id": "abscond", "target_id": None, "destination": None,
+                "free_text": None, "weapon_id": None,
+            })
+            auto_resolve_round(state)
+
+        char = state.characters[char_id]
+        assert any(c.condition_id == "absconding" for c in char.active_conditions)
+
+    def test_condition_stacks_on_second_attempt(self):
+        """A second Abscond attempt gives stacks == 2 on the absconding condition."""
+        from unittest.mock import patch
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        for _ in range(2):
+            open_turn(state)
+            with patch("engine.combat.random.randint", return_value=1):
+                submit_turn(state, char_id, "Abscond", combat_action={
+                    "action_id": "abscond", "target_id": None, "destination": None,
+                    "free_text": None, "weapon_id": None,
+                })
+                auto_resolve_round(state)
+
+        char = state.characters[char_id]
+        cond = next(c for c in char.active_conditions if c.condition_id == "absconding")
+        assert cond.stacks == 2
+
+    def test_stackable_condition_increments_stacks(self):
+        """apply_condition on a stackable condition increments stacks, not replaces."""
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        apply_condition(state, char_id, "absconding", duration=3)
+        apply_condition(state, char_id, "absconding", duration=3)
+
+        char = state.characters[char_id]
+        conds = [c for c in char.active_conditions if c.condition_id == "absconding"]
+        assert len(conds) == 1
+        assert conds[0].stacks == 2
+
+    def test_non_stackable_condition_still_replaces(self):
+        """Non-stackable conditions continue to replace (duration refresh)."""
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        apply_condition(state, char_id, "poisoned", duration=1)
+        apply_condition(state, char_id, "poisoned", duration=5)
+
+        char = state.characters[char_id]
+        conds = [c for c in char.active_conditions if c.condition_id == "poisoned"]
+        assert len(conds) == 1
+        assert conds[0].duration_rounds == 5
+        assert conds[0].stacks == 1
+
+    def test_stacks_multiply_stat_bonus(self):
+        """absconding at stacks=2 gives 2× the abscond_bonus modifier."""
+        from engine.data_loader import CONDITION_REGISTRY
+        state = self._make_combat_state()
+        char_id = self._char_id(state)
+
+        apply_condition(state, char_id, "absconding", duration=99)
+        apply_condition(state, char_id, "absconding", duration=99)
+
+        char = state.characters[char_id]
+        cond = next(c for c in char.active_conditions if c.condition_id == "absconding")
+        assert cond.stacks == 2
+
+        bonus_per_stack = CONDITION_REGISTRY["absconding"].stat_modifiers["abscond_bonus"]
+        total_bonus = bonus_per_stack * cond.stacks
+        assert total_bonus == bonus_per_stack * 2
+
+    def test_stacks_round_trip_serialization(self):
+        """stacks field survives serialize_active_condition / deserialize_active_condition."""
+        from serialization import deserialize_active_condition, serialize_active_condition
+        cond = ActiveCondition(condition_id="absconding", duration_rounds=3, stacks=4)
+        d = serialize_active_condition(cond)
+        assert d["stacks"] == 4
+        reloaded = deserialize_active_condition(d)
+        assert reloaded.stacks == 4
+
+    def test_stacks_defaults_to_one_on_old_saves(self):
+        """Old serialized dicts without 'stacks' key deserialize to stacks=1."""
+        from serialization import deserialize_active_condition
+        old_data = {"condition_id": "poisoned", "duration_rounds": 2, "source_id": None}
+        cond = deserialize_active_condition(old_data)
+        assert cond.stacks == 1


### PR DESCRIPTION
Progress on #54
To support Abscond, new condtions are added and conditions are optionally allowed to "stack." The Absconding condition grants a bonus to the success rate of abscond actions when applied, and using the Abscond condition applies this condition to all allies. Abscond is added to each job's action list and activated through the Act menu. The end strife button is removed.  A new _hook is added in combat.py. A successful Abscond calls exit_rounds.