### PR TITLE
feat: implement a-actions

### DIFF
--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -11,7 +11,7 @@ import discord
 
 from engine import equip_item, unequip_item
 from engine.azure_constants import UI_SLOTS, ItemSlot
-from engine.data_loader import ITEM_REGISTRY
+from engine.data_loader import CONDITION_REGISTRY, ITEM_REGISTRY
 from engine.item import EquipItem
 from store import save_session_async
 
@@ -83,7 +83,12 @@ def _character_sheet(char, state) -> str:
             item_name = "(empty)"
         slot_lines.append(f"  {_SLOT_LABELS[slot]}: {item_name}")
 
-    st = char.saving_throws
+    save_cond_bonus = sum(
+        CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("save", 0) * c.stacks
+        for c in char.active_conditions
+        if c.condition_id in CONDITION_REGISTRY
+    )
+    save_base = char.saving_throws.get("save", 0) + save_cond_bonus
     sheet_lines = [
         sep,
         f"{char.name}  \u2014  {char.character_class.value} Level {char.level}{leader_note}",
@@ -94,14 +99,8 @@ def _character_sheet(char, state) -> str:
         f"RSN {a.reason:+d}   SVY {a.savvy:+d}",
         sep,
         "Saves:",
-        "  PHY: {}   FNS: {}".format(
-            st.get("save", 0) + a.physique,
-            st.get("save", 0) + a.finesse,
-        ),
-        "  RSN: {}   SVY: {}".format(
-            st.get("save", 0) + a.reason,
-            st.get("save", 0) + a.savvy,
-        ),
+        f"  PHY: {save_base + a.physique}   FNS: {save_base + a.finesse}",
+        f"  RSN: {save_base + a.reason}   SVY: {save_base + a.savvy}",
         sep,
         "Equipped:",
         *slot_lines,

--- a/data/actions/abdicate.json
+++ b/data/actions/abdicate.json
@@ -1,0 +1,14 @@
+{
+  "action_id": "abdicate",
+  "label": "Abdicate",
+  "button_style": "primary",
+  "action_type": "move",
+  "description": "Move to a range band without provoking opportunity attacks.",
+  "requires_target": false,
+  "requires_destination": true,
+  "range_requirement": [],
+  "effect_tags": [
+    {"tag": "apply_condition", "condition": "abdication-immunity", "duration": 1, "target": "self"},
+    "move_to_band"
+  ]
+}

--- a/data/actions/abjure.json
+++ b/data/actions/abjure.json
@@ -1,0 +1,13 @@
+{
+  "action_id": "abjure",
+  "label": "Abjure",
+  "button_style": "secondary",
+  "action_type": "combat",
+  "description": "Enter a defensive stance. Gain +200 Defense, +200 Dodge, and +100 to all saves until next round.",
+  "requires_target": false,
+  "requires_destination": false,
+  "range_requirement": [],
+  "effect_tags": [
+    {"tag": "apply_condition", "condition": "abjuring", "duration": 1, "target": "self"}
+  ]
+}

--- a/data/actions/advance.json
+++ b/data/actions/advance.json
@@ -1,0 +1,11 @@
+{
+  "action_id": "advance",
+  "label": "Advance",
+  "button_style": "primary",
+  "action_type": "move",
+  "description": "Move to a range band as your Act action this round.",
+  "requires_target": false,
+  "requires_destination": true,
+  "range_requirement": [],
+  "effect_tags": ["move_to_band"]
+}

--- a/data/actions/aggrieve.json
+++ b/data/actions/aggrieve.json
@@ -1,0 +1,14 @@
+{
+  "action_id": "aggrieve",
+  "label": "Aggrieve",
+  "button_style": "danger",
+  "action_type": "attack",
+  "description": "Make a melee attack against a target in range.",
+  "requires_target": true,
+  "requires_destination": false,
+  "range_requirement": ["engage", "close_minus", "close_plus"],
+  "effect_tags": [
+    {"tag": "melee_attack", "dice": "1d6"},
+    "check_death"
+  ]
+}

--- a/data/actions/assail.json
+++ b/data/actions/assail.json
@@ -1,0 +1,15 @@
+{
+  "action_id": "assail",
+  "label": "Assail",
+  "button_style": "danger",
+  "action_type": "attack",
+  "description": "Powerful melee attack that adds your weapon's attack stat to damage. You become Undefended until next round.",
+  "requires_target": true,
+  "requires_destination": false,
+  "range_requirement": ["engage", "close_minus", "close_plus"],
+  "effect_tags": [
+    {"tag": "melee_attack", "dice": "1d6", "add_stat_bonus": true},
+    "check_death",
+    {"tag": "apply_condition", "condition": "undefended", "duration": 1, "target": "self"}
+  ]
+}

--- a/data/classes/dilettante.json
+++ b/data/classes/dilettante.json
@@ -8,5 +8,5 @@
   "primary_stat": "SVY",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "charge", "affect", "abscond"]
+  "combat_actions": ["advance", "abdicate", "aggrieve", "assail", "abjure", "abscond", "affect"]
 }

--- a/data/classes/knight.json
+++ b/data/classes/knight.json
@@ -8,5 +8,5 @@
   "primary_stat": "PHY",
   "max_level": 5,
   "description": "Knights who behave dishonorably may lose access to some or all of their knightly abilities. Minor infractions may incur short penalties, however major infractions could require a knight to perform a quest of atonement to reacquire their abilities.",
-  "combat_actions": ["attack", "charge", "affect", "abscond"]
+  "combat_actions": ["advance", "abdicate", "aggrieve", "assail", "abjure", "abscond", "affect"]
 }

--- a/data/classes/mage.json
+++ b/data/classes/mage.json
@@ -9,5 +9,5 @@
   "primary_stat": "RSN",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "charge", "affect", "abscond"]
+  "combat_actions": ["advance", "abdicate", "aggrieve", "assail", "abjure", "abscond", "affect"]
 }

--- a/data/classes/thief.json
+++ b/data/classes/thief.json
@@ -8,5 +8,5 @@
   "primary_stat": "FNS",
   "max_level": 5,
   "description": "",
-  "combat_actions": ["attack", "charge", "poison", "affect", "abscond"]
+  "combat_actions": ["advance", "abdicate", "aggrieve", "assail", "abjure", "abscond", "affect"]
 }

--- a/data/conditions/abdication-immunity.json
+++ b/data/conditions/abdication-immunity.json
@@ -1,0 +1,9 @@
+{
+  "condition_id": "abdication-immunity",
+  "label": "Abdication Immunity",
+  "duration_type": "rounds",
+  "stackable": false,
+  "hooks": {},
+  "stat_modifiers": {},
+  "grants_actions": []
+}

--- a/data/conditions/abjuring.json
+++ b/data/conditions/abjuring.json
@@ -1,0 +1,9 @@
+{
+  "condition_id": "abjuring",
+  "label": "Abjuring",
+  "duration_type": "rounds",
+  "stackable": false,
+  "hooks": {},
+  "stat_modifiers": {"defense": 200, "finesse": 200, "save": 100},
+  "grants_actions": []
+}

--- a/data/conditions/undefended.json
+++ b/data/conditions/undefended.json
@@ -1,0 +1,9 @@
+{
+  "condition_id": "undefended",
+  "label": "Undefended",
+  "duration_type": "rounds",
+  "stackable": false,
+  "hooks": {},
+  "stat_modifiers": {"defense": -9999},
+  "grants_actions": []
+}

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -641,8 +641,9 @@ def _hook_weapon_attack(
     base_roll = roll_dice_expr(dice)["total"]
     is_crit = random.randint(1, 10) == 1
     crit_bonus = roll_dice_expr(dice)["total"] if is_crit else 0
-    min_damage = max(1, str_mod)
-    damage = max(min_damage, base_roll + crit_bonus + str_mod)
+    stat_bonus = str_mod if params.get("add_stat_bonus") and actor_char else 0
+    min_damage = 1
+    damage = max(min_damage, base_roll + crit_bonus + stat_bonus)
     mitigation = (
         _effective_resistance(state, target_id)
         if targets_stat == "resistance"
@@ -843,22 +844,26 @@ def _hook_apply_condition(
     params:   dict,
 ) -> None:
     """
-    Apply a condition to action.target_id.
+    Apply a condition to action.target_id, or to actor_id if params["target"] == "self".
 
     params:
       condition  (str, required) — condition_id to apply
       duration   (int, default 3) — duration in rounds; omit for permanent
+      target     (str, optional) — "self" to apply to the actor instead of action.target_id
     """
     condition_id = params.get("condition")
     if not condition_id:
         log.append("[apply_condition: 'condition' param is required]")
         return
 
-    if action is None or action.target_id is None:
-        log.append(f"[apply_condition({condition_id}): no target specified]")
-        return
+    if params.get("target") == "self":
+        target_id = actor_id
+    else:
+        if action is None or action.target_id is None:
+            log.append(f"[apply_condition({condition_id}): no target specified]")
+            return
+        target_id = action.target_id
 
-    target_id   = action.target_id
     actor_name  = _combatant_name(state, actor_id)
     target_name = _combatant_name(state, target_id)
 
@@ -872,7 +877,10 @@ def _hook_apply_condition(
 
     cond_def = CONDITION_REGISTRY.get(condition_id)
     label    = cond_def.label if cond_def else condition_id
-    log.append(f"{actor_name} applies {label} to {target_name}! ({duration} rounds)")
+    if target_id == actor_id:
+        log.append(f"{actor_name} is now {label}! ({duration} rounds)")
+    else:
+        log.append(f"{actor_name} applies {label} to {target_name}! ({duration} rounds)")
 
 
 def _hook_skip_action(

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1077,15 +1077,12 @@ class TestPoisonAction:
         state.characters[char_id].hp_max = 20
         return state, list(state.characters.keys())[0], npc
 
-    def test_poison_in_thief_actions(self):
+    def test_poison_not_in_any_class_actions(self):
         from engine import CLASS_DEFINITIONS
-        actions = CLASS_DEFINITIONS["THIEF"].combat_actions
-        assert "poison" in actions
-        assert actions.index("poison") < actions.index("affect")
-
-    def test_poison_not_in_fighter_actions(self):
-        from engine import CLASS_DEFINITIONS
-        assert "poison" not in CLASS_DEFINITIONS["KNIGHT"].combat_actions
+        for key, job_def in CLASS_DEFINITIONS.items():
+            assert "poison" not in job_def.combat_actions, (
+                f"poison should be removed from {key} combat_actions"
+            )
 
     def test_poison_has_no_range_requirement(self):
         from engine import ACTION_REGISTRY
@@ -1864,3 +1861,206 @@ class TestAbscondRoll:
         old_data = {"condition_id": "poisoned", "duration_rounds": 2, "source_id": None}
         cond = deserialize_active_condition(old_data)
         assert cond.stacks == 1
+
+
+# ---------------------------------------------------------------------------
+# A-Actions
+# ---------------------------------------------------------------------------
+
+class TestAActions:
+    """Tests for the new A-action set: aggrieve, advance, abdicate, assail, abjure."""
+
+    def _setup_combat(self, npc_hp=50, npc_def=0):
+        """Enter rounds, open a turn, return (state, char_id, npc_id).
+        Character HP is 50 so NPC counter-attacks don't kill them mid-test.
+        """
+        state = _make_state_with_npc()
+        npc = state.npcs_in_current_room[0]
+        npc.hp_current = npc_hp
+        npc.hp_max = npc_hp
+        npc.defense = npc_def
+        char = list(state.characters.values())[0]
+        char.hp_current = 50
+        char.hp_max = 50
+        enter_rounds(state)
+        open_turn(state)
+        return state, list(state.characters.keys())[0], npc.npc_id
+
+    def _submit(self, state, char_id, action):
+        from models import PlayerTurnSubmission
+        state.current_turn.submissions = [PlayerTurnSubmission(
+            character_id=char_id,
+            action_text=action.action_id,
+            is_latest=True,
+            combat_action=action.to_dict(),
+        )]
+
+    # --- Aggrieve ---
+
+    def test_aggrieve_deals_damage(self):
+        """Aggrieve hits and reduces NPC HP (AC=1 guarantees hit)."""
+        state, char_id, npc_id = self._setup_combat(npc_hp=50, npc_def=0)
+        state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        self._submit(state, char_id, CombatAction(action_id="aggrieve", target_id=npc_id))
+        result = auto_resolve_round(state)
+        assert result.ok
+        npc = state.npcs_in_current_room[0]
+        assert npc.hp_current < 50
+
+    def test_aggrieve_no_stat_bonus_in_damage(self):
+        """Default melee_attack tag does not add stat bonus — max damage is bounded by dice."""
+        from engine.combat import _hook_weapon_attack
+        state, char_id, npc_id = self._setup_combat(npc_hp=9999, npc_def=0)
+        state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        # Give NPC very low finesse so we always hit.
+        state.battlefield.combatants[npc_id].range_band = RangeBand.ENGAGE
+        npc = state.npcs_in_current_room[0]
+        npc.hp_current = 9999
+        npc.hp_max = 9999
+        npc.defense = 0
+        # Run many attacks and check max damage never exceeds max dice (1d6=6) plus possible crit.
+        # A 1d6 with a crit doubles to 12. str_mod excluded.
+        log: list[str] = []
+        action = CombatAction(action_id="aggrieve", target_id=npc_id)
+        for _ in range(30):
+            _hook_weapon_attack(state, char_id, action, log, {"dice": "1d6"})
+        # No assertion on exact values — just verifying it runs without error.
+
+    # --- Advance ---
+
+    def test_advance_moves_actor_via_act_slot(self):
+        """Advance queued through the act slot moves the character."""
+        state, char_id, npc_id = self._setup_combat()
+        state.battlefield.combatants[char_id].range_band = RangeBand.FAR_MINUS
+        self._submit(state, char_id, CombatAction(action_id="advance", destination=RangeBand.CLOSE_MINUS))
+        result = auto_resolve_round(state)
+        assert result.ok
+        assert state.battlefield.combatants[char_id].range_band == RangeBand.CLOSE_MINUS
+
+    def test_advance_does_not_require_target(self):
+        from engine.data_loader import ACTION_REGISTRY
+        a = ACTION_REGISTRY["advance"]
+        assert a.requires_target is False
+        assert a.requires_destination is True
+
+    # --- Abdicate ---
+
+    def test_abdicate_moves_and_applies_immunity_condition(self):
+        """Abdicate applies abdication-immunity to actor and moves."""
+        state, char_id, npc_id = self._setup_combat()
+        state.battlefield.combatants[char_id].range_band = RangeBand.FAR_MINUS
+        self._submit(state, char_id, CombatAction(action_id="abdicate", destination=RangeBand.CLOSE_MINUS))
+        auto_resolve_round(state)
+        # Movement happened
+        assert state.battlefield.combatants[char_id].range_band == RangeBand.CLOSE_MINUS
+        # Condition was applied (duration=1, ticks off at end of round)
+        # Verify via round_log that it was applied
+        assert any("abdication" in e.lower() for e in state.battlefield.round_log)
+
+    # --- apply_condition target=self ---
+
+    def test_apply_condition_self_targets_actor_not_action_target(self):
+        """target='self' applies condition to actor even when action has a different target_id."""
+        from engine.combat import _hook_apply_condition
+        state, char_id, npc_id = self._setup_combat()
+        char = state.characters[char_id]
+        npc = state.npcs_in_current_room[0]
+        action = CombatAction(action_id="abjure", target_id=npc_id)
+        log: list[str] = []
+        _hook_apply_condition(state, char_id, action, log,
+                              {"condition": "abjuring", "duration": 1, "target": "self"})
+        assert any(c.condition_id == "abjuring" for c in char.active_conditions)
+        assert not any(c.condition_id == "abjuring" for c in npc.active_conditions)
+
+    def test_apply_condition_self_works_with_no_action(self):
+        """target='self' works when action=None (no target_id available)."""
+        from engine.combat import _hook_apply_condition
+        state, char_id, _ = self._setup_combat()
+        char = state.characters[char_id]
+        log: list[str] = []
+        _hook_apply_condition(state, char_id, None, log,
+                              {"condition": "abjuring", "duration": 1, "target": "self"})
+        assert any(c.condition_id == "abjuring" for c in char.active_conditions)
+
+    # --- Assail ---
+
+    def test_assail_applies_undefended_to_actor(self):
+        """After Assail, undefended was applied to the actor (visible in round log).
+        The condition expires at end-of-round (duration=1), so we check the log.
+        """
+        state, char_id, npc_id = self._setup_combat(npc_hp=9999, npc_def=0)
+        state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        self._submit(state, char_id, CombatAction(action_id="assail", target_id=npc_id))
+        auto_resolve_round(state)
+        assert any("undefended" in e.lower() for e in state.battlefield.round_log)
+
+    def test_undefended_condition_floors_defense_to_zero(self):
+        """undefended's -9999 defense modifier floors Character.defense to 0."""
+        state, char_id, _ = self._setup_combat()
+        char = state.characters[char_id]
+        char.active_conditions = [ActiveCondition(condition_id="undefended", duration_rounds=1)]
+        assert char.defense == 0
+
+    def test_assail_add_stat_bonus_adds_stat_to_damage(self):
+        """add_stat_bonus=true adds str_mod to damage; without it damage is dice-only."""
+        from engine.combat import _hook_weapon_attack
+        # Set up: NPC with huge HP so we can compare, def=0, guaranteed hit (finesse=1)
+        state, char_id, npc_id = self._setup_combat(npc_hp=99999, npc_def=0)
+        state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        npc = state.npcs_in_current_room[0]
+        npc.hp_current = 99999
+        npc.hp_max = 99999
+
+        import random
+        action = CombatAction(action_id="assail", target_id=npc_id)
+        log: list[str] = []
+        # Patch randomness: always hit, always roll max dice
+        original_randint = random.randint
+        call_count = [0]
+        def mock_randint(a, b):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return b  # attack roll: max (always hit)
+            if call_count[0] == 2:
+                return 1  # crit check: no crit
+            return b  # dice roll: max
+        random.randint = mock_randint
+        try:
+            hp_before = npc.hp_current
+            _hook_weapon_attack(state, char_id, action, log, {"dice": "1d6", "add_stat_bonus": True})
+            hp_after = npc.hp_current
+        finally:
+            random.randint = original_randint
+
+        # With add_stat_bonus, damage = max(1, 6 + str_mod). Just verify damage was applied.
+        assert hp_after < hp_before
+
+    # --- Abjure ---
+
+    def test_abjure_applies_abjuring_condition_to_self(self):
+        """Abjure applies the abjuring condition to the actor (visible in round log).
+        The condition expires at end-of-round (duration=1), so we check the log.
+        """
+        state, char_id, npc_id = self._setup_combat()
+        self._submit(state, char_id, CombatAction(action_id="abjure"))
+        auto_resolve_round(state)
+        assert any("abjuring" in e.lower() for e in state.battlefield.round_log)
+
+    def test_abjuring_increases_defense_and_finesse(self):
+        """abjuring condition grants +200 defense and +200 finesse."""
+        from engine.combat import _effective_finesse
+        state, char_id, _ = self._setup_combat()
+        char = state.characters[char_id]
+        # Set a known baseline (no gear, no conditions, zero finesse) for deterministic math.
+        char.active_conditions = []
+        char.ability_scores.finesse = 0
+        assert char.defense == 0
+        assert _effective_finesse(state, char_id) == 0
+        # Apply abjuring and verify both stats increase by exactly 200
+        char.active_conditions = [ActiveCondition(condition_id="abjuring", duration_rounds=1)]
+        assert char.defense == 200
+        assert _effective_finesse(state, char_id) == 200

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -138,9 +138,9 @@ class TestProductionDataFiles:
         assert j.base_save == 4
         assert j.primary_stat == "PHY"
         assert j.max_level == 5
-        assert "attack" in j.combat_actions
-        assert "move"   not in j.combat_actions  # Move is a top-level button, not an Act action
-        assert "affect" in j.combat_actions
+        assert "aggrieve" in j.combat_actions
+        assert "move"     not in j.combat_actions  # Move is a top-level button, not an Act action
+        assert "affect"   in j.combat_actions
 
     def test_job_thief_values(self):
         j = CLASS_DEFINITIONS["THIEF"]
@@ -149,7 +149,7 @@ class TestProductionDataFiles:
         assert j.weapon_rank == "D"
         assert j.base_save == 2
         assert j.primary_stat == "FNS"
-        assert "poison" in j.combat_actions
+        assert "assail" in j.combat_actions
 
     def test_job_mage_values(self):
         j = CLASS_DEFINITIONS["MAGE"]
@@ -163,9 +163,23 @@ class TestProductionDataFiles:
         assert j.display_name == "Dilettante"
         assert j.primary_stat == "SVY"
 
-    def test_condition_registry_has_four_conditions(self):
-        for cid in ("poisoned", "stunned", "strengthened", "entangled"):
+    def test_condition_registry_has_expected_conditions(self):
+        for cid in (
+            "poisoned", "stunned", "strengthened", "entangled", "absconding",
+            "abdication-immunity", "undefended", "abjuring",
+        ):
             assert cid in CONDITION_REGISTRY
+
+    def test_all_classes_have_a_actions(self):
+        expected = {"advance", "abdicate", "aggrieve", "assail", "abjure", "abscond", "affect"}
+        for key, job_def in CLASS_DEFINITIONS.items():
+            assert expected == set(job_def.combat_actions), (
+                f"Class {key} has wrong combat_actions: {job_def.combat_actions}"
+            )
+
+    def test_new_actions_exist_in_registry(self):
+        for action_id in ("aggrieve", "advance", "abdicate", "assail", "abjure"):
+            assert action_id in ACTION_REGISTRY, f"Missing action: {action_id}"
 
     def test_all_job_combat_actions_exist_in_registry(self):
         """Every action ID referenced by any job must exist in ACTION_REGISTRY."""


### PR DESCRIPTION
Progress on #54
-engine/combat.py: added "target": "self" param to apply conditions to actor; fixed default damage formula to not include stat bonus (unless added by a condition)
-cogs/character_views.py: save display includes condition modifiers -data/: added new actions and corresponding conditions. Classes now start with the 7 A's
-updated tests