### PR TITLE
fix: range requirement now obeys game rules

### DIFF
--- a/data/actions/abdicate.json
+++ b/data/actions/abdicate.json
@@ -6,7 +6,7 @@
   "description": "Move to a range band without provoking opportunity attacks.",
   "requires_target": false,
   "requires_destination": true,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": [
     {"tag": "apply_condition", "condition": "abdication-immunity", "duration": 1, "target": "self"},
     "move_to_band"

--- a/data/actions/abjure.json
+++ b/data/actions/abjure.json
@@ -6,7 +6,7 @@
   "description": "Enter a defensive stance. Gain +200 Defense, +200 Dodge, and +100 to all saves until next round.",
   "requires_target": false,
   "requires_destination": false,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": [
     {"tag": "apply_condition", "condition": "abjuring", "duration": 1, "target": "self"}
   ]

--- a/data/actions/abscond.json
+++ b/data/actions/abscond.json
@@ -6,6 +6,6 @@
   "description": "Attempt to flee combat. Roll 1d1000 + Finesse vs 500 + highest enemy Finesse. Each prior attempt this combat eases the roll.",
   "requires_target": false,
   "requires_destination": false,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": ["abscond_roll"]
 }

--- a/data/actions/advance.json
+++ b/data/actions/advance.json
@@ -6,6 +6,6 @@
   "description": "Move to a range band as your Act action this round.",
   "requires_target": false,
   "requires_destination": true,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": ["move_to_band"]
 }

--- a/data/actions/affect.json
+++ b/data/actions/affect.json
@@ -6,6 +6,6 @@
   "description": "Freely describe your action. Always requires DM resolution — turn will not auto-resolve.",
   "requires_target": false,
   "requires_destination": false,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": []
 }

--- a/data/actions/aggrieve.json
+++ b/data/actions/aggrieve.json
@@ -6,7 +6,7 @@
   "description": "Make a melee attack against a target in range.",
   "requires_target": true,
   "requires_destination": false,
-  "range_requirement": ["engage", "close_minus", "close_plus"],
+  "range_requirement": "weapon",
   "effect_tags": [
     {"tag": "melee_attack", "dice": "1d6"},
     "check_death"

--- a/data/actions/assail.json
+++ b/data/actions/assail.json
@@ -6,7 +6,7 @@
   "description": "Powerful melee attack that adds your weapon's attack stat to damage. You become Undefended until next round.",
   "requires_target": true,
   "requires_destination": false,
-  "range_requirement": ["engage", "close_minus", "close_plus"],
+  "range_requirement": "weapon",
   "effect_tags": [
     {"tag": "melee_attack", "dice": "1d6", "add_stat_bonus": true},
     "check_death",

--- a/data/actions/attack.json
+++ b/data/actions/attack.json
@@ -6,7 +6,7 @@
   "description": "Make a melee attack against a target in range.",
   "requires_target": true,
   "requires_destination": false,
-  "range_requirement": ["engage", "close_minus", "close_plus"],
+  "range_requirement": "weapon",
   "effect_tags": [
     {"tag": "melee_attack", "dice": "1d6"},
     "check_death"

--- a/data/actions/charge.json
+++ b/data/actions/charge.json
@@ -6,7 +6,7 @@
   "description": "Move to a range band and immediately attack a target there.",
   "requires_target": true,
   "requires_destination": true,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": [
     "move_to_band",
     {"tag": "melee_attack", "dice": "1d6"},

--- a/data/actions/move.json
+++ b/data/actions/move.json
@@ -6,6 +6,6 @@
   "description": "Move to an adjacent range band.",
   "requires_target": false,
   "requires_destination": true,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": ["move_to_band"]
 }

--- a/data/actions/poison.json
+++ b/data/actions/poison.json
@@ -6,7 +6,7 @@
   "description": "Apply poison to a target at any range. The target takes 1d4 damage at the end of each round.",
   "requires_target": true,
   "requires_destination": false,
-  "range_requirement": [],
+  "range_requirement": null,
   "effect_tags": [
     {"tag": "apply_condition", "condition": "poisoned", "duration": 3}
   ]

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -80,6 +80,11 @@ _BAND_ORDER: list[RangeBand] = [
 _BAND_INDEX: dict[RangeBand, int] = {b: i for i, b in enumerate(_BAND_ORDER)}
 
 
+def _band_distance(a: RangeBand, b: RangeBand) -> int:
+    """Absolute number of band steps between two range bands."""
+    return abs(_BAND_INDEX[a] - _BAND_INDEX[b])
+
+
 def _adjacent_bands(band: RangeBand) -> list[RangeBand]:
     """Return the bands directly adjacent (one step either side) to band."""
     idx = _BAND_INDEX[band]
@@ -372,14 +377,18 @@ def _execute_action(
         log.append(f"[Unknown action '{action.action_id}' — skipped]")
         return
 
-    if action_def.range_requirement:
-        cs = state.battlefield.combatants.get(actor_id)
-        if cs and cs.range_band.value not in action_def.range_requirement:
-            log.append(
-                f"{_combatant_name(state, actor_id)} cannot use {action_def.label} "
-                f"from {cs.range_band.value}."
-            )
-            return
+    if isinstance(action_def.range_requirement, int):
+        actor_cs  = state.battlefield.combatants.get(actor_id)
+        target_cs = state.battlefield.combatants.get(action.target_id) if action.target_id else None
+        if actor_cs and target_cs:
+            dist = _band_distance(actor_cs.range_band, target_cs.range_band)
+            if dist > action_def.range_requirement:
+                log.append(
+                    f"{_combatant_name(state, actor_id)} cannot use {action_def.label} "
+                    f"from {actor_cs.range_band.value} — target is {dist} band(s) away "
+                    f"(max {action_def.range_requirement})."
+                )
+                return
 
     for hook_entry in action_def.effect_tags:
         _dispatch_hook(hook_entry, state, actor_id, action, log)
@@ -395,8 +404,6 @@ def _npc_decide(
     cs:     CombatantState,
 ) -> CombatAction | None:
     """Simple NPC AI: move toward players if far; attack lowest-HP player if in range."""
-    attack_def = ACTION_REGISTRY.get("attack")
-
     living_players = [
         (cid, pcs) for cid, pcs in state.battlefield.combatants.items()
         if pcs.is_player and _is_alive(state, cid)
@@ -404,12 +411,11 @@ def _npc_decide(
     if not living_players:
         return None
 
-    if attack_def and (
-        not attack_def.range_requirement
-        or cs.range_band.value in attack_def.range_requirement
-    ):
-        target_id = _lowest_hp_player(state, living_players)
-        if target_id:
+    _NPC_WEAPON_RANGE = 0
+    target_id = _lowest_hp_player(state, living_players)
+    if target_id:
+        target_cs = state.battlefield.combatants.get(target_id)
+        if target_cs and _band_distance(cs.range_band, target_cs.range_band) <= _NPC_WEAPON_RANGE:
             return CombatAction(action_id="attack", target_id=target_id)
 
     destination = _step_toward(cs.range_band, RangeBand.ENGAGE)
@@ -582,6 +588,32 @@ def _hook_weapon_attack(
     target_id   = action.target_id
     actor_name  = _combatant_name(state, actor_id)
     target_name = _combatant_name(state, target_id)
+
+    # Range check: determine weapon range then compare to band distance
+    actor_cs  = state.battlefield.combatants.get(actor_id)
+    target_cs = state.battlefield.combatants.get(target_id)
+    if actor_cs and target_cs:
+        weapon_range = 0  # default: melee (also used for NPCs without equipped weapons)
+        maybe_char = state.characters.get(actor_id)
+        if maybe_char:
+            weapons = maybe_char.equipped_weapons()
+            if weapons:
+                _, w_def = weapons[0]
+                if action.weapon_id:
+                    w_pair = next(
+                        ((i, d) for i, d in weapons if i.item_id == action.weapon_id),
+                        None,
+                    )
+                    if w_pair:
+                        _, w_def = w_pair
+                weapon_range = getattr(w_def, "range", 0)
+        dist = _band_distance(actor_cs.range_band, target_cs.range_band)
+        if dist > weapon_range:
+            log.append(
+                f"{actor_name} cannot reach {target_name} "
+                f"— {dist} band(s) away, weapon range is {weapon_range}."
+            )
+            return
 
     actor_char = state.characters.get(actor_id)
     actor_npc  = _find_npc(state, actor_id)

--- a/engine/data_loader.py
+++ b/engine/data_loader.py
@@ -92,20 +92,20 @@ class ActionDef:
     description        : Tooltip / help text.
     requires_target    : True → platform must collect a target_id before submitting.
     requires_destination: True → platform must collect a RangeBand destination.
-    range_requirement  : List of RangeBand values (as strings) the attacker must
-                         occupy to use this action.  Empty list = no restriction.
+    range_requirement  : Maximum band distance from actor to target, or "weapon" to use
+                         the equipped weapon's range, or None for no restriction.
     effect_tags        : Ordered list of hook entries dispatched by _dispatch_hook().
                          Each entry is a plain tag string or a hook object dict.
     """
-    action_id:            str             = ""
-    label:                str             = ""
-    button_style:         str             = "secondary"
-    action_type:          str             = ""
-    description:          str             = ""
-    requires_target:      bool            = False
-    requires_destination: bool            = False
-    range_requirement:    list[str]       = field(default_factory=list)
-    effect_tags:          list[HookEntry] = field(default_factory=list)
+    action_id:            str              = ""
+    label:                str              = ""
+    button_style:         str              = "secondary"
+    action_type:          str              = ""
+    description:          str              = ""
+    requires_target:      bool             = False
+    requires_destination: bool             = False
+    range_requirement:    int | str | None = None
+    effect_tags:          list[HookEntry]  = field(default_factory=list)
 
 
 @dataclass
@@ -355,7 +355,7 @@ def _load_action(path: Path) -> ActionDef:
         description=data.get("description", ""),
         requires_target=bool(data["requires_target"]),
         requires_destination=bool(data["requires_destination"]),
-        range_requirement=list(data.get("range_requirement", [])),
+        range_requirement=data.get("range_requirement"),
         effect_tags=raw_tags,
     )
 

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -700,6 +700,9 @@ class TestNPCDecide:
         npc = state.npcs_in_current_room[0]
         cs = state.battlefield.combatants[npc.npc_id]
         cs.range_band = RangeBand.ENGAGE
+        # Place player at ENGAGE too so distance == 0 (within NPC melee range)
+        char_id = next(iter(state.characters))
+        state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
 
         action = _npc_decide(state, npc.npc_id, cs)
         assert action is not None
@@ -1086,7 +1089,7 @@ class TestPoisonAction:
 
     def test_poison_has_no_range_requirement(self):
         from engine import ACTION_REGISTRY
-        assert ACTION_REGISTRY["poison"].range_requirement == []
+        assert ACTION_REGISTRY["poison"].range_requirement is None
 
     def test_poison_requires_target(self):
         from engine import ACTION_REGISTRY
@@ -1788,15 +1791,23 @@ class TestAbscondRoll:
         from unittest.mock import patch
         state = self._make_combat_state()
         char_id = self._char_id(state)
+        npc = self._npc(state)
+        # Player must act before NPC so the NPC hasn't moved to ENGAGE yet when
+        # the second abscond fires. (NPC has melee range 0 and moves toward ENGAGE
+        # each round it can't attack — if it reaches ENGAGE first it blocks the attempt.)
+        state.battlefield.combatants[char_id].initiative = 100
+        state.battlefield.combatants[npc.npc_id].initiative = 1
 
         for _ in range(2):
             open_turn(state)
             with patch("engine.combat.random.randint", return_value=1):
+                # submit_turn auto-resolves when all players have submitted; do NOT
+                # call auto_resolve_round again or the NPC gets a free extra move
+                # (no player submission) that brings it to ENGAGE, blocking the next attempt.
                 submit_turn(state, char_id, "Abscond", combat_action={
                     "action_id": "abscond", "target_id": None, "destination": None,
                     "free_text": None, "weapon_id": None,
                 })
-                auto_resolve_round(state)
 
         char = state.characters[char_id]
         cond = next(c for c in char.active_conditions if c.condition_id == "absconding")
@@ -2064,3 +2075,73 @@ class TestAActions:
         char.active_conditions = [ActiveCondition(condition_id="abjuring", duration_rounds=1)]
         assert char.defense == 200
         assert _effective_finesse(state, char_id) == 200
+
+    # --- Weapon range enforcement ---
+
+    def test_melee_weapon_blocked_when_not_at_engage(self):
+        """Attack with range-0 weapon fails when actor is not at ENGAGE with target."""
+        from engine.combat import _hook_weapon_attack
+        from engine.item import Weapon
+        from models import InventoryItem
+        state, char_id, npc_id = self._setup_combat(npc_hp=100, npc_def=0)
+        # Equip a melee weapon (range=0)
+        char = state.characters[char_id]
+        weapon = Weapon("melee_w", "Sword", "C", "Sword", "physique", "1d6", range=0)
+        char.inventory.append(InventoryItem(item_id="melee_w"))
+        char.equipped_slots["main_hand"] = "melee_w"
+        from engine.data_loader import ITEM_REGISTRY
+        ITEM_REGISTRY["melee_w"] = weapon
+        # Place actor at CLOSE_MINUS (1 band away from target at ENGAGE)
+        state.battlefield.combatants[char_id].range_band = RangeBand.CLOSE_MINUS
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        action = CombatAction(action_id="attack", target_id=npc_id)
+        log: list[str] = []
+        _hook_weapon_attack(state, char_id, action, log, {})
+        assert any("cannot reach" in line for line in log)
+        assert state.npcs_in_current_room[0].hp_current == 100
+
+    def test_reach_weapon_hits_from_adjacent_band(self):
+        """Attack with range-1 weapon succeeds from one band away."""
+        from unittest.mock import patch
+
+        from engine.combat import _hook_weapon_attack
+        from engine.item import Weapon
+        from models import InventoryItem
+        state, char_id, npc_id = self._setup_combat(npc_hp=100, npc_def=0)
+        # Equip a reach weapon (range=1)
+        char = state.characters[char_id]
+        weapon = Weapon("reach_w", "Greatspear", "C", "Polearm", "physique", "1d8", range=1)
+        char.inventory.append(InventoryItem(item_id="reach_w"))
+        char.equipped_slots["main_hand"] = "reach_w"
+        from engine.data_loader import ITEM_REGISTRY
+        ITEM_REGISTRY["reach_w"] = weapon
+        # Actor at CLOSE_MINUS (distance 1 to ENGAGE target)
+        state.battlefield.combatants[char_id].range_band = RangeBand.CLOSE_MINUS
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        action = CombatAction(action_id="attack", target_id=npc_id)
+        log: list[str] = []
+        with patch("engine.combat.random.randint", return_value=1000):
+            _hook_weapon_attack(state, char_id, action, log, {})
+        assert not any("cannot reach" in line for line in log)
+        assert state.npcs_in_current_room[0].hp_current < 100
+
+    def test_reach_weapon_blocked_two_bands_away(self):
+        """Attack with range-1 weapon fails when 2 bands away from target."""
+        from engine.combat import _hook_weapon_attack
+        from engine.item import Weapon
+        from models import InventoryItem
+        state, char_id, npc_id = self._setup_combat(npc_hp=100, npc_def=0)
+        char = state.characters[char_id]
+        weapon = Weapon("reach_w2", "Greatspear", "C", "Polearm", "physique", "1d8", range=1)
+        char.inventory.append(InventoryItem(item_id="reach_w2"))
+        char.equipped_slots["main_hand"] = "reach_w2"
+        from engine.data_loader import ITEM_REGISTRY
+        ITEM_REGISTRY["reach_w2"] = weapon
+        # Actor at FAR_MINUS (distance 2 to ENGAGE target)
+        state.battlefield.combatants[char_id].range_band = RangeBand.FAR_MINUS
+        state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
+        action = CombatAction(action_id="attack", target_id=npc_id)
+        log: list[str] = []
+        _hook_weapon_attack(state, char_id, action, log, {})
+        assert any("cannot reach" in line for line in log)
+        assert state.npcs_in_current_room[0].hp_current == 100

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -60,7 +60,7 @@ _VALID_ACTION = {
     "description":          "Melee attack.",
     "requires_target":      True,
     "requires_destination": False,
-    "range_requirement":    ["engage"],
+    "range_requirement":    "weapon",
     "effect_tags":          [{"tag": "melee_attack", "dice": "1d6"}],
 }
 


### PR DESCRIPTION
Resolves #77
Previously, actions had range_requirement which just set a list of range bands where the action would be able to fire. Now, range_requirement may be an integer range, null (no range limit) or "weapon" to inherit the weapon's range.
engine/data_loader.py
  - ActionDef.range_requirement: list[str] → int | str | None, engine/combat.py
  - Added _band_distance(a, b) -> int helper
  - _execute_action: replaced band-membership check with isinstance(range_requirement, int) distance check against target
  - _hook_weapon_attack: added range check at entry — resolves actor's equipped weapon range (default 0) and fails if distance > weapon range
  - _npc_decide: replaced attack_def band-list check with _band_distance(...) <= 0 Tests updated, json updated