### PR TITLE
feat: requires_target now allows ally/self target

### DIFF
--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -760,7 +760,7 @@ class ClassActionView(discord.ui.View):
     """
     Per-player ephemeral view listing the character's available combat actions.
     Each button either:
-      • opens TargetSelectView (requires_target actions)
+      • opens TargetSelectView (requires_target != "none" actions)
       • opens DestinationSelectView (requires_destination actions)
       • opens AffectModal (affect type)
     Built dynamically from ACTION_REGISTRY entries in action_ids.
@@ -820,12 +820,20 @@ class ClassActionView(discord.ui.View):
                 )
                 return
 
-            if action_def.requires_target:
+            combatant_targets = []
+            if action_def.requires_target == "self":
+                # add the owner to the targets
+                combatant_targets = [owner_char]
+            elif action_def.requires_target == "allies":
+                # Build target select from active characters
+                combatant_targets = state.activeCharacters()
+            elif action_def.requires_target == "enemies":
                 # Build target select from living NPCs in current room
-                npc_targets = [
+                combatant_targets = [
                     n for n in state.npcs_in_current_room if n.status != "dead"
                 ]
-                if not npc_targets:
+            if action_def.requires_target != "none":
+                if not combatant_targets:
                     await interaction.response.send_message(
                         "No valid targets in this room.", ephemeral=True
                     )
@@ -834,7 +842,7 @@ class ClassActionView(discord.ui.View):
                     action_id=action_id,
                     char_id=self.char_id,
                     channel_id=self.channel_id,
-                    npc_targets=npc_targets,
+                    combatant_targets=combatant_targets,
                     then_destination=action_def.requires_destination,
                 )
                 await interaction.response.edit_message(
@@ -887,7 +895,7 @@ class TargetSelectView(discord.ui.View):
         action_id:        str,
         char_id:          UUID,
         channel_id:       str,
-        npc_targets,
+        combatant_targets,
         then_destination: bool = False,
     ):
         super().__init__(timeout=180)
@@ -898,11 +906,11 @@ class TargetSelectView(discord.ui.View):
 
         options = [
             discord.SelectOption(
-                label=npc.name,
-                value=str(npc.npc_id),
-                description=f"HP: {npc.hp_current}/{npc.hp_max}",
+                label=getattr(combatant, name, ""),
+                value=str(getattr(combatant, npc_id, combatant.character_id)),
+                description=f"HP: {combatant.hp_current}/{combatant.hp_max}",
             )
-            for npc in npc_targets[:25]   # Discord SelectMenu max 25 options
+            for combatant in combatant_targets[:25]   # Discord SelectMenu max 25 options
         ]
 
         select = discord.ui.Select(

--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -69,7 +69,7 @@ from engine import (
     say,
     submit_turn,
 )
-from models import RangeBand, SessionMode, TurnStatus
+from models import GameState, RangeBand, SessionMode, TurnStatus
 from store import (
     get_session,
     notify_dm_of_turn_close,

--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -820,22 +820,30 @@ class ClassActionView(discord.ui.View):
                 )
                 return
 
-            combatant_targets = []
             if action_def.requires_target == "self":
-                # add the owner to the targets
-                combatant_targets = [owner_char]
-            elif action_def.requires_target == "allies":
-                # Build target select from active characters
-                combatant_targets = state.activeCharacters()
-            elif action_def.requires_target == "enemies":
-                # Build target select from living NPCs in current room
-                combatant_targets = [
-                    n for n in state.npcs_in_current_room if n.status != "dead"
-                ]
-            if action_def.requires_target != "none":
+                # Target is the actor; skip selection entirely
+                partial = CombatAction(action_id=action_id, target_id=owner_char.character_id)
+                current_band = (
+                    state.battlefield.combatants[self.char_id].range_band
+                    if state.battlefield and self.char_id in state.battlefield.combatants
+                    else None
+                )
+                await _dispatch_with_target(
+                    interaction, self.char_id, self.channel_id, partial,
+                    action_def.requires_destination, current_band, state, owner_char.name,
+                )
+                return
+
+            elif action_def.requires_target in ("allies", "enemies"):
+                if action_def.requires_target == "allies":
+                    combatant_targets = state.active_characters
+                else:
+                    combatant_targets = [
+                        n for n in state.npcs_in_current_room if n.status != "dead"
+                    ]
                 if not combatant_targets:
                     await interaction.response.send_message(
-                        "No valid targets in this room.", ephemeral=True
+                        "No valid targets.", ephemeral=True
                     )
                     return
                 view = TargetSelectView(
@@ -876,6 +884,53 @@ class ClassActionView(discord.ui.View):
 
 
 # ---------------------------------------------------------------------------
+# Combat: target dispatch helper
+# ---------------------------------------------------------------------------
+
+async def _dispatch_with_target(
+    interaction:      discord.Interaction,
+    char_id:          UUID,
+    channel_id:       str,
+    partial:          CombatAction,
+    then_destination: bool,
+    current_band,
+    state:            GameState,
+    owner_name:       str,
+) -> None:
+    """After a target is known, route to weapon picker → destination → submit."""
+    owner_char_obj = state.characters.get(char_id)
+    weapons = owner_char_obj.equipped_weapons() if owner_char_obj else []
+
+    if len(weapons) > 1:
+        view = WeaponPickerView(
+            char_id=char_id,
+            channel_id=channel_id,
+            weapons=weapons,
+            partial=partial,
+            then_destination=then_destination,
+            current_band=current_band,
+        )
+        await interaction.response.edit_message(
+            content=f"**{owner_name}** — select a weapon:",
+            view=view,
+        )
+    elif then_destination:
+        view = DestinationSelectView(
+            action_id=partial.action_id,
+            char_id=char_id,
+            channel_id=channel_id,
+            current_band=current_band,
+            partial_action=partial,
+        )
+        await interaction.response.edit_message(
+            content=f"**{owner_name}** — select destination:",
+            view=view,
+        )
+    else:
+        await _submit_combat_action(interaction, char_id, channel_id, partial)
+
+
+# ---------------------------------------------------------------------------
 # Combat: TargetSelectView  (transient ephemeral — timeout=180)
 # ---------------------------------------------------------------------------
 
@@ -906,8 +961,8 @@ class TargetSelectView(discord.ui.View):
 
         options = [
             discord.SelectOption(
-                label=getattr(combatant, name, ""),
-                value=str(getattr(combatant, npc_id, combatant.character_id)),
+                label=combatant.name,
+                value=str(getattr(combatant, "character_id", None) or combatant.npc_id),
                 description=f"HP: {combatant.hp_current}/{combatant.hp_max}",
             )
             for combatant in combatant_targets[:25]   # Discord SelectMenu max 25 options
@@ -942,36 +997,10 @@ class TargetSelectView(discord.ui.View):
             else None
         )
 
-        owner_char_obj = state.characters.get(self.char_id)
-        weapons = owner_char_obj.equipped_weapons() if owner_char_obj else []
-
-        if len(weapons) > 1:
-            view = WeaponPickerView(
-                char_id=self.char_id,
-                channel_id=self.channel_id,
-                weapons=weapons,
-                partial=partial,
-                then_destination=self.then_destination,
-                current_band=current_band,
-            )
-            await interaction.response.edit_message(
-                content=f"**{owner_char.name}** — select a weapon:",
-                view=view,
-            )
-        elif self.then_destination:
-            view = DestinationSelectView(
-                action_id=self.action_id,
-                char_id=self.char_id,
-                channel_id=self.channel_id,
-                current_band=current_band,
-                partial_action=partial,
-            )
-            await interaction.response.edit_message(
-                content=f"**{owner_char.name}** — select destination:",
-                view=view,
-            )
-        else:
-            await _submit_combat_action(interaction, self.char_id, self.channel_id, partial)
+        await _dispatch_with_target(
+            interaction, self.char_id, self.channel_id, partial,
+            self.then_destination, current_band, state, owner_char.name,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/data/actions/abdicate.json
+++ b/data/actions/abdicate.json
@@ -4,7 +4,7 @@
   "button_style": "primary",
   "action_type": "move",
   "description": "Move to a range band without provoking opportunity attacks.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": true,
   "range_requirement": null,
   "effect_tags": [

--- a/data/actions/abjure.json
+++ b/data/actions/abjure.json
@@ -4,7 +4,7 @@
   "button_style": "secondary",
   "action_type": "combat",
   "description": "Enter a defensive stance. Gain +200 Defense, +200 Dodge, and +100 to all saves until next round.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": false,
   "range_requirement": null,
   "effect_tags": [

--- a/data/actions/abscond.json
+++ b/data/actions/abscond.json
@@ -4,7 +4,7 @@
   "button_style": "secondary",
   "action_type": "combat",
   "description": "Attempt to flee combat. Roll 1d1000 + Finesse vs 500 + highest enemy Finesse. Each prior attempt this combat eases the roll.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": false,
   "range_requirement": null,
   "effect_tags": ["abscond_roll"]

--- a/data/actions/advance.json
+++ b/data/actions/advance.json
@@ -4,7 +4,7 @@
   "button_style": "primary",
   "action_type": "move",
   "description": "Move to a range band as your Act action this round.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": true,
   "range_requirement": null,
   "effect_tags": ["move_to_band"]

--- a/data/actions/affect.json
+++ b/data/actions/affect.json
@@ -4,7 +4,7 @@
   "button_style": "secondary",
   "action_type": "affect",
   "description": "Freely describe your action. Always requires DM resolution — turn will not auto-resolve.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": false,
   "range_requirement": null,
   "effect_tags": []

--- a/data/actions/aggrieve.json
+++ b/data/actions/aggrieve.json
@@ -4,7 +4,7 @@
   "button_style": "danger",
   "action_type": "attack",
   "description": "Make a melee attack against a target in range.",
-  "requires_target": true,
+  "requires_target": "enemies",
   "requires_destination": false,
   "range_requirement": "weapon",
   "effect_tags": [

--- a/data/actions/assail.json
+++ b/data/actions/assail.json
@@ -4,7 +4,7 @@
   "button_style": "danger",
   "action_type": "attack",
   "description": "Powerful melee attack that adds your weapon's attack stat to damage. You become Undefended until next round.",
-  "requires_target": true,
+  "requires_target": "enemies",
   "requires_destination": false,
   "range_requirement": "weapon",
   "effect_tags": [

--- a/data/actions/attack.json
+++ b/data/actions/attack.json
@@ -4,7 +4,7 @@
   "button_style": "danger",
   "action_type": "attack",
   "description": "Make a melee attack against a target in range.",
-  "requires_target": true,
+  "requires_target": "enemies",
   "requires_destination": false,
   "range_requirement": "weapon",
   "effect_tags": [

--- a/data/actions/charge.json
+++ b/data/actions/charge.json
@@ -4,7 +4,7 @@
   "button_style": "danger",
   "action_type": "attack",
   "description": "Move to a range band and immediately attack a target there.",
-  "requires_target": true,
+  "requires_target": "enemies",
   "requires_destination": true,
   "range_requirement": null,
   "effect_tags": [

--- a/data/actions/equip_item.json
+++ b/data/actions/equip_item.json
@@ -4,7 +4,7 @@
   "button_style": "secondary",
   "action_type": "combat",
   "description": "Equip an item from your inventory. Consumes your action for this round.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": false,
   "range_requirement": null,
   "effect_tags": ["resolve_equip"]

--- a/data/actions/move.json
+++ b/data/actions/move.json
@@ -4,7 +4,7 @@
   "button_style": "primary",
   "action_type": "move",
   "description": "Move to an adjacent range band.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": true,
   "range_requirement": null,
   "effect_tags": ["move_to_band"]

--- a/data/actions/poison.json
+++ b/data/actions/poison.json
@@ -4,7 +4,7 @@
   "button_style": "secondary",
   "action_type": "attack",
   "description": "Apply poison to a target at any range. The target takes 1d4 damage at the end of each round.",
-  "requires_target": true,
+  "requires_target": "enemies",
   "requires_destination": false,
   "range_requirement": null,
   "effect_tags": [

--- a/data/actions/strengthen.json
+++ b/data/actions/strengthen.json
@@ -1,0 +1,13 @@
+{
+  "action_id": "strengthen",
+  "label": "Strengthen",
+  "button_style": "success",
+  "action_type": "combat",
+  "description": "Bolster an ally's physique, granting them the Strengthened condition for 3 rounds.",
+  "requires_target": "allies",
+  "requires_destination": false,
+  "range_requirement": null,
+  "effect_tags": [
+    {"tag": "apply_condition", "condition": "strengthened", "duration": 3}
+  ]
+}

--- a/data/actions/unequip_item.json
+++ b/data/actions/unequip_item.json
@@ -4,7 +4,7 @@
   "button_style": "secondary",
   "action_type": "combat",
   "description": "Unequip an item from a slot. Consumes your action for this round.",
-  "requires_target": false,
+  "requires_target": "none",
   "requires_destination": false,
   "range_requirement": null,
   "effect_tags": ["resolve_unequip"]

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -117,7 +117,7 @@ class CombatAction:
     A fully specified combat action ready for resolution.
 
     action_id     : Key into ACTION_REGISTRY.
-    target_id     : UUID of the target combatant (when ActionDef.requires_target).
+    target_id     : UUID of the target combatant (when ActionDef.requires_target is not "none").
     destination   : RangeBand to move to (when ActionDef.requires_destination).
     free_text     : Player-supplied description for "affect" actions.
     is_affect     : True when this is a free-text Affect submission.

--- a/engine/data_loader.py
+++ b/engine/data_loader.py
@@ -90,7 +90,7 @@ class ActionDef:
     button_style       : Discord button style: primary/secondary/danger/success.
     action_type        : Logical category: attack | move | affect.
     description        : Tooltip / help text.
-    requires_target    : True → platform must collect a target_id before submitting.
+    requires_target    : "self", "allies", "enemies", or None
     requires_destination: True → platform must collect a RangeBand destination.
     range_requirement  : Maximum band distance from actor to target, or "weapon" to use
                          the equipped weapon's range, or None for no restriction.
@@ -102,7 +102,7 @@ class ActionDef:
     button_style:         str              = "secondary"
     action_type:          str              = ""
     description:          str              = ""
-    requires_target:      bool             = False
+    requires_target:      str              = "none"
     requires_destination: bool             = False
     range_requirement:    int | str | None = None
     effect_tags:          list[HookEntry]  = field(default_factory=list)
@@ -245,6 +245,7 @@ _SKILL_REQUIRED = {
 
 _VALID_BUTTON_STYLES  = {"primary", "secondary", "danger", "success"}
 _VALID_ACTION_TYPES   = {"attack", "move", "affect", "combat"}
+_VALID_ACTION_TARGET  = {"self", "allies", "enemies", "none"}
 _VALID_DURATION_TYPES = {"rounds", "permanent"}
 _VALID_HOOK_NAMES     = {
     "on_turn_start", "on_turn_end", "on_attack", "on_hit",
@@ -344,6 +345,12 @@ def _load_action(path: Path) -> ActionDef:
             f"{path}: invalid action_type '{atype}'; must be one of {_VALID_ACTION_TYPES}"
         )
 
+    atarget = data["requires_target"]
+    if atarget not in _VALID_ACTION_TARGET:
+        raise ValueError(
+            f"{path}: invalid action_type '{atarget}'; must be one of {_VALID_ACTION_TARGET}"
+        )
+
     raw_tags = list(data["effect_tags"])
     for i, entry in enumerate(raw_tags):
         _validate_effect_tag(entry, path, i)
@@ -354,7 +361,7 @@ def _load_action(path: Path) -> ActionDef:
         button_style=style,
         action_type=atype,
         description=data.get("description", ""),
-        requires_target=bool(data["requires_target"]),
+        requires_target=data["requires_target"],
         requires_destination=bool(data["requires_destination"]),
         range_requirement=data.get("range_requirement"),
         effect_tags=raw_tags,

--- a/engine/data_loader.py
+++ b/engine/data_loader.py
@@ -90,7 +90,7 @@ class ActionDef:
     button_style       : Discord button style: primary/secondary/danger/success.
     action_type        : Logical category: attack | move | affect.
     description        : Tooltip / help text.
-    requires_target    : "self", "allies", "enemies", or None
+    requires_target    : "self" | "allies" | "enemies" | "none"
     requires_destination: True → platform must collect a RangeBand destination.
     range_requirement  : Maximum band distance from actor to target, or "weapon" to use
                          the equipped weapon's range, or None for no restriction.
@@ -348,7 +348,7 @@ def _load_action(path: Path) -> ActionDef:
     atarget = data["requires_target"]
     if atarget not in _VALID_ACTION_TARGET:
         raise ValueError(
-            f"{path}: invalid action_type '{atarget}'; must be one of {_VALID_ACTION_TARGET}"
+            f"{path}: invalid requires_target '{atarget}'; must be one of {_VALID_ACTION_TARGET}"
         )
 
     raw_tags = list(data["effect_tags"])

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1526,7 +1526,7 @@ class TestHookObjectValidation:
             (p / "classes").mkdir()
             (p / "actions" / "stab.json").write_text(json.dumps({
                 "action_id": "stab", "label": "Stab", "button_style": "danger",
-                "action_type": "attack", "requires_target": True,
+                "action_type": "attack", "requires_target": "enemies",
                 "requires_destination": False, "range_requirement": [],
                 "effect_tags": [{"tag": "melee_attack", "dice": "1d4"}, "check_death"],
             }))
@@ -1548,7 +1548,7 @@ class TestHookObjectValidation:
             (p / "classes").mkdir()
             (p / "actions" / "bad.json").write_text(json.dumps({
                 "action_id": "bad", "label": "Bad", "button_style": "danger",
-                "action_type": "attack", "requires_target": False,
+                "action_type": "attack", "requires_target": "none",
                 "requires_destination": False, "range_requirement": [],
                 "effect_tags": [{"dice": "1d6"}],   # missing "tag"
             }))
@@ -1953,7 +1953,7 @@ class TestAActions:
     def test_advance_does_not_require_target(self):
         from engine.data_loader import ACTION_REGISTRY
         a = ACTION_REGISTRY["advance"]
-        assert a.requires_target is False
+        assert a.requires_target == "none"
         assert a.requires_destination is True
 
     # --- Abdicate ---
@@ -2145,6 +2145,65 @@ class TestAActions:
         _hook_weapon_attack(state, char_id, action, log, {})
         assert any("cannot reach" in line for line in log)
         assert state.npcs_in_current_room[0].hp_current == 100
+
+    # --- Strengthen ---
+
+    def test_strengthen_requires_allies(self):
+        from engine.data_loader import ACTION_REGISTRY
+        assert ACTION_REGISTRY["strengthen"].requires_target == "allies"
+
+    def test_strengthen_applies_condition_to_ally(self):
+        """Strengthen applies the strengthened condition to the target ally."""
+        from engine import add_npc, register_room
+        from models import Room
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Caster", CharacterClass.MAGE,  "Pack A", owner_id="u1")
+        create_character(state, "Ally",   CharacterClass.KNIGHT, "Pack A", owner_id="u2")
+        start_session(state)
+        room = Room(name="Hall", description="Hall.")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        add_npc(state, NPC(name="Goblin", hp_current=5, hp_max=5, defense=0))
+        enter_rounds(state)
+        open_turn(state)
+        char_ids = list(state.characters.keys())
+        # Pin initiatives so caster (char_ids[0]) acts first
+        state.battlefield.combatants[char_ids[0]].initiative = 100
+        state.battlefield.combatants[char_ids[1]].initiative = 50
+        caster_id = char_ids[0]
+        ally_id    = char_ids[1]
+        from models import PlayerTurnSubmission
+        state.current_turn.submissions = [
+            PlayerTurnSubmission(
+                character_id=caster_id, action_text="Strengthen",
+                is_latest=True,
+                combat_action=CombatAction(action_id="strengthen", target_id=ally_id).to_dict(),
+            ),
+            PlayerTurnSubmission(
+                character_id=ally_id, action_text="Advance",
+                is_latest=True,
+                combat_action=CombatAction(action_id="advance",
+                                           destination=RangeBand.CLOSE_MINUS).to_dict(),
+            ),
+        ]
+        result = auto_resolve_round(state)
+        assert result.ok
+        ally = state.characters[ally_id]
+        assert any(c.condition_id == "strengthened" for c in ally.active_conditions)
+
+    def test_apply_condition_self_tag_applies_to_actor_not_target(self):
+        """apply_condition with target='self' in assail applies undefended to actor, not the NPC."""
+        from engine.combat import _hook_apply_condition
+        state, char_id, npc_id = self._setup_combat()
+        char = state.characters[char_id]
+        npc  = state.npcs_in_current_room[0]
+        action = CombatAction(action_id="assail", target_id=npc_id)
+        log: list[str] = []
+        _hook_apply_condition(state, char_id, action, log,
+                              {"condition": "undefended", "duration": 1, "target": "self"})
+        assert any(c.condition_id == "undefended" for c in char.active_conditions)
+        assert not any(c.condition_id == "undefended" for c in npc.active_conditions)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1093,7 +1093,7 @@ class TestPoisonAction:
 
     def test_poison_requires_target(self):
         from engine import ACTION_REGISTRY
-        assert ACTION_REGISTRY["poison"].requires_target == "enemies" 
+        assert ACTION_REGISTRY["poison"].requires_target == "enemies"
 
     def test_poison_applies_condition_to_target(self):
         state, char_id, npc = self._thief_state()

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -1093,7 +1093,7 @@ class TestPoisonAction:
 
     def test_poison_requires_target(self):
         from engine import ACTION_REGISTRY
-        assert ACTION_REGISTRY["poison"].requires_target is True
+        assert ACTION_REGISTRY["poison"].requires_target == "enemies" 
 
     def test_poison_applies_condition_to_target(self):
         state, char_id, npc = self._thief_state()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -58,7 +58,7 @@ _VALID_ACTION = {
     "button_style":         "danger",
     "action_type":          "attack",
     "description":          "Melee attack.",
-    "requires_target":      True,
+    "requires_target":      "enemies",
     "requires_destination": False,
     "range_requirement":    "weapon",
     "effect_tags":          [{"tag": "melee_attack", "dice": "1d6"}],
@@ -104,7 +104,7 @@ class TestProductionDataFiles:
         assert a.label == "Attack"
         assert a.button_style == "danger"
         assert a.action_type == "attack"
-        assert a.requires_target is True
+        assert a.requires_target == "enemies"
         assert a.requires_destination is False
         tags = [e["tag"] if isinstance(e, dict) else e for e in a.effect_tags]
         assert "melee_attack" in tags
@@ -114,14 +114,14 @@ class TestProductionDataFiles:
         a = ACTION_REGISTRY["move"]
         assert a.action_type == "move"
         assert a.requires_destination is True
-        assert a.requires_target is False
+        assert a.requires_target == "none"
         tags = [e["tag"] if isinstance(e, dict) else e for e in a.effect_tags]
         assert "move_to_band" in tags
 
     def test_action_affect_values(self):
         a = ACTION_REGISTRY["affect"]
         assert a.action_type == "affect"
-        assert a.requires_target is False
+        assert a.requires_target == "none"
         assert a.requires_destination is False
         assert a.effect_tags == []
 


### PR DESCRIPTION
Work in progress, untested. The requires_target field in actions json now needs a string that specifies what kind of targets are acceptable. Needs to be tested by adding an action that targets self and adding it to a class.
tests/test_combat_engine.py and tests/test_data_loader.py fail and need updates