### PR TITLE
feat: add utility spell type

### DIFF
--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -13,7 +13,7 @@ from engine import equip_item, unequip_item
 from engine.azure_constants import UI_SLOTS, ItemSlot
 from engine.character import CharacterManager
 from engine.data_loader import CONDITION_REGISTRY, ITEM_REGISTRY
-from engine.item import EquipItem
+from engine.item import EquipItem, UtilitySpell
 from store import save_session_async
 
 # Human-readable labels for each slot.
@@ -125,7 +125,8 @@ def _character_sheet(char, state) -> str:
                     _charges = f" ({_child.charges}/{_cdefn.maxCharges})"
             else:
                 _charges = ""
-            _inv_parts.append(f"    \u2514 {_cname}{_charges}")
+            _desc = f" — {_cdefn.description}" if isinstance(_cdefn, UtilitySpell) and _cdefn.description else ""
+            _inv_parts.append(f"    \u2514 {_cname}{_charges}{_desc}")
     inv_lines = "\n".join(_inv_parts) if _inv_parts else "  (empty)"
 
     # Equipped slots summary

--- a/engine/azure_constants.py
+++ b/engine/azure_constants.py
@@ -77,6 +77,7 @@ class ItemType(StrEnum):
     WEAPON = "weapon"
     CHARGE_WEAPON = "charge_weapon"
     CONTAINER = "container"
+    UTILITY_SPELL = "utility_spell"
 
 class SkillType(Enum):
     SIMPLE = 0

--- a/engine/character.py
+++ b/engine/character.py
@@ -454,7 +454,7 @@ class CharacterManager:
                 # Add each contained spell as its own InventoryItem with per-character charges.
                 for spell_id in defn.contained_item_ids:
                     spell_def = ITEM_REGISTRY.get(spell_id)
-                    spell_charges = spell_def.maxCharges if isinstance(spell_def, ChargeWeapon) else None
+                    spell_charges = spell_def.maxCharges if hasattr(spell_def, "maxCharges") else None
                     char.inventory.append(InventoryItem(
                         item_id=spell_id,
                         quantity=1,

--- a/engine/item.py
+++ b/engine/item.py
@@ -318,6 +318,38 @@ class ContainerItem(EquipItem):
         return exportData
 
 
+class UtilitySpell(EquipItem):
+    """
+    A non-combat spell that lives inside a ContainerItem spellbook.
+    No equipment slot — inventory-only via container_id.
+    Effects are narrated by the DM; no engine effect code.
+    """
+    ITEM_TYPE = ItemType.UTILITY_SPELL.value
+
+    def __init__(self, item_id, name, rank="", tags=None,
+                 description="", otherAbilities="",
+                 maxCharges=-1, rechargePeriod=RechargePeriod.NEVER,
+                 purchaseable=False, price=0, isLight=False, **kwargs):
+        super().__init__(
+            item_id=item_id, name=name, rank=rank,
+            tags=tags or [], description=description,
+            otherAbilities=otherAbilities, isLight=isLight,
+            purchaseable=purchaseable, price=price,
+        )
+        self.slot = None
+        self.maxCharges = maxCharges
+        self.rechargePeriod = rechargePeriod
+
+    def toDictionary(self):
+        exportData = super().toDictionary()
+        exportData.update({
+            ItemData.ITEM_TYPE.value: UtilitySpell.ITEM_TYPE,
+            ItemData.MAX_CHARGES.value: self.maxCharges,
+            ItemData.RECHARGE_PERIOD.value: self.rechargePeriod,
+        })
+        return exportData
+
+
 def parseChargeString(charge_str):
     recharge = RechargePeriod.NEVER
 
@@ -442,6 +474,16 @@ def createItemFromData(itemData):
                 **base, **equip,
                 contained_item_ids = itemData.get(ItemData.CONTAINED_ITEMS, []),
                 slot               = itemData.get(ItemData.SLOT, None),
+            )
+
+        case ItemType.UTILITY_SPELL:
+            return UtilitySpell(
+                **base,
+                rank            = itemData.get(ItemData.RANK, ""),
+                tags            = itemData.get(ItemData.TAGS, []),
+                otherAbilities  = itemData.get(ItemData.OTHER_ABILITIES, ""),
+                maxCharges      = itemData.get(ItemData.MAX_CHARGES, -1),
+                rechargePeriod  = itemData.get(ItemData.RECHARGE_PERIOD, RechargePeriod.NEVER),
             )
 
         case _:

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -723,22 +723,41 @@ class TestUtilitySpellbookGive:
 
 class TestUtilitySpellCharacterSheet:
     def test_character_sheet_shows_utility_spell_description(self, state_mage, utility_spellbook_id):
-        """Character sheet should include spell name, charges, and description under its container."""
+        """Inventory display lines for utility spells include name, charges, and description.
+
+        Replicates the contained-item rendering from cogs/character_views._character_sheet
+        without importing the cog (which pulls in discord).
+        """
         assert utility_spellbook_id is not None
         char = _get_char(state_mage)
         give_item(state_mage, char.character_id, utility_spellbook_id)
 
-        from cogs.character_views import _character_sheet
-        sheet = _character_sheet(char, state_mage)
+        # Build the same contained-item lines that _character_sheet produces.
+        contained: dict[str, list] = {}
+        for inv in char.inventory:
+            if inv.container_id:
+                contained.setdefault(inv.container_id, []).append(inv)
+
+        lines = []
+        for child in contained.get(utility_spellbook_id, []):
+            cdefn = ITEM_REGISTRY.get(child.item_id)
+            cname = cdefn.name if cdefn else child.item_id
+            if child.charges is not None and cdefn is not None and hasattr(cdefn, "maxCharges"):
+                charges = f" (\u221e)" if cdefn.maxCharges < 0 else f" ({child.charges}/{cdefn.maxCharges})"
+            else:
+                charges = ""
+            desc = f" \u2014 {cdefn.description}" if isinstance(cdefn, UtilitySpell) and cdefn.description else ""
+            lines.append(f"    \u2514 {cname}{charges}{desc}")
 
         book_def = ITEM_REGISTRY[utility_spellbook_id]
         for spell_id in book_def.contained_item_ids:
             spell_def = ITEM_REGISTRY.get(spell_id)
             if not isinstance(spell_def, UtilitySpell):
                 continue
-            assert spell_def.name in sheet
+            matching = [ln for ln in lines if spell_def.name in ln]
+            assert matching, f"{spell_def.name} not found in rendered lines"
             if spell_def.description:
-                assert spell_def.description in sheet
+                assert any(spell_def.description in ln for ln in matching)
 
 
 class TestUtilitySpellPersistence:

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -743,7 +743,7 @@ class TestUtilitySpellCharacterSheet:
             cdefn = ITEM_REGISTRY.get(child.item_id)
             cname = cdefn.name if cdefn else child.item_id
             if child.charges is not None and cdefn is not None and hasattr(cdefn, "maxCharges"):
-                charges = f" (\u221e)" if cdefn.maxCharges < 0 else f" ({child.charges}/{cdefn.maxCharges})"
+                charges = " (\u221e)" if cdefn.maxCharges < 0 else f" ({child.charges}/{cdefn.maxCharges})"
             else:
                 charges = ""
             desc = f" \u2014 {cdefn.description}" if isinstance(cdefn, UtilitySpell) and cdefn.description else ""

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -18,7 +18,7 @@ import pytest
 from engine import create_character, equip_item, give_item, remove_item, unequip_item
 from engine.azure_constants import UI_SLOTS, ItemSlot
 from engine.data_loader import ITEM_REGISTRY
-from engine.item import ChargeWeapon, ContainerItem, Gear, Weapon
+from engine.item import ChargeWeapon, ContainerItem, Gear, UtilitySpell, Weapon
 from models import (
     CharacterClass,
     InventoryItem,
@@ -630,3 +630,139 @@ class TestSpellbookChargeTracking:
                 i.item_id == spell_id and i.container_id == spellbook_id
                 for i in char.inventory
             )
+
+
+# ---------------------------------------------------------------------------
+# UtilitySpell tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def utility_spell_id():
+    """Return an item_id for a UtilitySpell in ITEM_REGISTRY, or None."""
+    for item_id, defn in ITEM_REGISTRY.items():
+        if isinstance(defn, UtilitySpell):
+            return item_id
+    return None
+
+
+@pytest.fixture
+def utility_spellbook_id():
+    """Return a slot-less ContainerItem that contains utility spells."""
+    for item_id, defn in ITEM_REGISTRY.items():
+        if (
+            isinstance(defn, ContainerItem)
+            and defn.slot is None
+            and any(
+                isinstance(ITEM_REGISTRY.get(sid), UtilitySpell)
+                for sid in defn.contained_item_ids
+            )
+        ):
+            return item_id
+    return None
+
+
+class TestUtilitySpellLoading:
+    def test_utility_spell_in_registry(self, utility_spell_id):
+        assert utility_spell_id is not None, "No UtilitySpell found in ITEM_REGISTRY — check items.json"
+        defn = ITEM_REGISTRY[utility_spell_id]
+        assert isinstance(defn, UtilitySpell)
+        assert defn.slot is None
+        assert defn.description != "" or defn.otherAbilities != "" or defn.maxCharges is not None
+
+    def test_utility_spell_fields_populated(self):
+        """viviu_2 is a known finite-charge utility spell — verify its fields."""
+        defn = ITEM_REGISTRY.get("viviu_2")
+        assert defn is not None, "viviu_2 not in ITEM_REGISTRY"
+        assert isinstance(defn, UtilitySpell)
+        assert defn.maxCharges == 5
+        assert defn.description == "Heals 100 damage"
+        assert defn.rank == "V"
+
+    def test_infinite_charge_utility_spell(self):
+        """viviu_1 has max_charges -1 (infinite)."""
+        defn = ITEM_REGISTRY.get("viviu_1")
+        assert defn is not None
+        assert defn.maxCharges == -1
+
+
+class TestUtilitySpellbookGive:
+    def test_give_utility_spellbook_adds_contained_spells(self, state_mage, utility_spellbook_id):
+        assert utility_spellbook_id is not None, "No slot-less ContainerItem with utility spells found"
+        char = _get_char(state_mage)
+        give_item(state_mage, char.character_id, utility_spellbook_id)
+
+        book_def = ITEM_REGISTRY[utility_spellbook_id]
+        for spell_id in book_def.contained_item_ids:
+            spell_inv = next(
+                (i for i in char.inventory
+                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                None,
+            )
+            assert spell_inv is not None, f"Spell {spell_id} not added to inventory"
+            spell_def = ITEM_REGISTRY.get(spell_id)
+            if isinstance(spell_def, UtilitySpell) and spell_def.maxCharges > 0:
+                assert spell_inv.charges == spell_def.maxCharges
+
+    def test_utility_spells_not_independently_equippable(self, state_mage, utility_spellbook_id):
+        """Contained utility spells should have container_id set and no slot."""
+        assert utility_spellbook_id is not None
+        char = _get_char(state_mage)
+        give_item(state_mage, char.character_id, utility_spellbook_id)
+
+        book_def = ITEM_REGISTRY[utility_spellbook_id]
+        for spell_id in book_def.contained_item_ids:
+            spell_inv = next(
+                (i for i in char.inventory
+                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                None,
+            )
+            assert spell_inv is not None
+            assert spell_inv.container_id == utility_spellbook_id
+            assert not spell_inv.equipped
+
+
+class TestUtilitySpellCharacterSheet:
+    def test_character_sheet_shows_utility_spell_description(self, state_mage, utility_spellbook_id):
+        """Character sheet should include spell name, charges, and description under its container."""
+        assert utility_spellbook_id is not None
+        char = _get_char(state_mage)
+        give_item(state_mage, char.character_id, utility_spellbook_id)
+
+        from cogs.character_views import _character_sheet
+        sheet = _character_sheet(char, state_mage)
+
+        book_def = ITEM_REGISTRY[utility_spellbook_id]
+        for spell_id in book_def.contained_item_ids:
+            spell_def = ITEM_REGISTRY.get(spell_id)
+            if not isinstance(spell_def, UtilitySpell):
+                continue
+            assert spell_def.name in sheet
+            if spell_def.description:
+                assert spell_def.description in sheet
+
+
+class TestUtilitySpellPersistence:
+    def test_persistence_round_trip(self, state_mage, utility_spellbook_id):
+        """Contained utility spell charges and container_id survive serialize/deserialize."""
+        assert utility_spellbook_id is not None
+        char = _get_char(state_mage)
+        give_item(state_mage, char.character_id, utility_spellbook_id)
+
+        restored = deserialize_state(serialize_state(state_mage))
+        rest_char = next(iter(restored.characters.values()))
+
+        book_def = ITEM_REGISTRY[utility_spellbook_id]
+        for spell_id in book_def.contained_item_ids:
+            orig = next(
+                (i for i in char.inventory
+                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                None,
+            )
+            restored_inv = next(
+                (i for i in rest_char.inventory
+                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                None,
+            )
+            assert restored_inv is not None, f"Spell {spell_id} lost after round-trip"
+            assert restored_inv.charges == orig.charges
+            assert restored_inv.container_id == utility_spellbook_id


### PR DESCRIPTION
Resolves #62 given the design decisions made. Healing spells for now are entirely non-combat and require dungeon turns. As such they are resolved manually by the DM for now. The UtilitySpell class exists to allow spells to have charge/recharge information that displays properly on character sheets.