### PR TITLE
feat: spell recharge updates

### DIFF
--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import discord
 
 from engine import equip_item, unequip_item
-from engine.azure_constants import RechargePeriod, UI_SLOTS, ItemSlot
+from engine.azure_constants import UI_SLOTS, ItemSlot, RechargePeriod
 from engine.character import CharacterManager
 from engine.data_loader import CONDITION_REGISTRY, ITEM_REGISTRY
 from engine.item import EquipItem, UtilitySpell

--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import discord
 
 from engine import equip_item, unequip_item
-from engine.azure_constants import UI_SLOTS, ItemSlot
+from engine.azure_constants import RechargePeriod, UI_SLOTS, ItemSlot
 from engine.character import CharacterManager
 from engine.data_loader import CONDITION_REGISTRY, ITEM_REGISTRY
 from engine.item import EquipItem, UtilitySpell
@@ -117,6 +117,13 @@ def _character_sheet(char, state) -> str:
         for _child in _contained.get(i.item_id, []):
             _cdefn = ITEM_REGISTRY.get(_child.item_id)
             _cname = _cdefn.name if _cdefn else _child.item_id
+            _period = getattr(_cdefn, "rechargePeriod", None)
+            if _period == RechargePeriod.DAY:
+                _period_tag = " [D]"
+            elif _period == RechargePeriod.ENCOUNTER:
+                _period_tag = " [E]"
+            else:
+                _period_tag = ""
             if _child.charges is not None and _cdefn is not None and hasattr(_cdefn, "maxCharges"):
                 if _cdefn.maxCharges < 0:
                     _charges = " (\u221e)"
@@ -125,7 +132,7 @@ def _character_sheet(char, state) -> str:
             else:
                 _charges = ""
             _desc = f" — {_cdefn.description}" if isinstance(_cdefn, UtilitySpell) and _cdefn.description else ""
-            _inv_parts.append(f"    \u2514 {_cname}{_charges}{_desc}")
+            _inv_parts.append(f"    \u2514 {_cname}{_period_tag}{_charges}{_desc}")
     inv_lines = "\n".join(_inv_parts) if _inv_parts else "  (empty)"
 
     # Equipped slots summary

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -173,6 +173,18 @@ def give_item(state: GameState, character_id, item_id: str, quantity: int = 1):
     return cm.give_item(state, character_id, item_id, quantity)
 
 
+def adjust_spell_charges(state: GameState, character_id, item_id: str, delta: int):
+    """Adjust a spell's current charges by delta, clamped to [0, maxCharges]."""
+    cm = CharacterManager()
+    return cm.adjust_spell_charges(state, character_id, item_id, delta)
+
+
+def recharge_day_spells(state: GameState, character_id):
+    """Restore all DAY-period spells to full charges for the given character."""
+    cm = CharacterManager()
+    return cm.recharge_day_spells(state, character_id)
+
+
 def add_npc(state: GameState, npc):
     """Add an NPC."""
     nm = NPCManager()
@@ -777,4 +789,6 @@ __all__ = [
     "check_level_up",
     "distribute_xp",
     "check_random_encounter",
+    "adjust_spell_charges",
+    "recharge_day_spells",
 ]

--- a/engine/character.py
+++ b/engine/character.py
@@ -483,6 +483,83 @@ class CharacterManager:
         qty_str = f"{quantity}x " if quantity > 1 else ""
         return _ok(state, f"{char.name} received {qty_str}{defn.name}.")
 
+    def adjust_spell_charges(
+        self,
+        state: GameState,
+        character_id,
+        item_id: str,
+        delta: int,
+    ):
+        """
+        Adjust a spell's current charges by delta (positive or negative).
+
+        Works for ChargeWeapon and UtilitySpell items with finite maxCharges.
+        Result is clamped to [0, maxCharges]. Infinite spells (maxCharges < 0)
+        are rejected.
+        """
+        from engine import _now
+
+        char = state.characters.get(character_id)
+        if char is None:
+            return _err(state, f"Character {character_id} not found.")
+
+        from engine.item import UtilitySpell
+        inv_item = next(
+            (i for i in char.inventory if i.item_id == item_id and i.charges is not None),
+            None,
+        )
+        if inv_item is None:
+            return _err(state, f"No chargeable spell '{item_id}' found on {char.name}.")
+
+        defn = ITEM_REGISTRY.get(item_id)
+        if defn is None or not isinstance(defn, (ChargeWeapon, UtilitySpell)):
+            return _err(state, f"'{item_id}' is not a spell.")
+        if defn.maxCharges < 0:
+            return _err(state, f"'{defn.name}' has infinite charges and cannot be adjusted.")
+
+        inv_item.charges = max(0, min(defn.maxCharges, inv_item.charges + delta))
+        state.updated_at = _now()
+        return _ok(state, f"{defn.name} charges: {inv_item.charges}/{defn.maxCharges}.")
+
+    def recharge_day_spells(
+        self,
+        state: GameState,
+        character_id,
+    ):
+        """
+        Restore all DAY-period spells to full charges for the given character.
+
+        Returns an EngineResult with the count of spells recharged.
+        """
+        from engine import _now
+        from engine.azure_constants import RechargePeriod
+        from engine.item import UtilitySpell
+
+        char = state.characters.get(character_id)
+        if char is None:
+            return _err(state, f"Character {character_id} not found.")
+
+        count = 0
+        for inv_item in char.inventory:
+            if inv_item.charges is None:
+                continue
+            defn = ITEM_REGISTRY.get(inv_item.item_id)
+            if defn is None:
+                continue
+            if not isinstance(defn, (ChargeWeapon, UtilitySpell)):
+                continue
+            if getattr(defn, "rechargePeriod", None) != RechargePeriod.DAY:
+                continue
+            if defn.maxCharges < 0:
+                continue
+            inv_item.charges = defn.maxCharges
+            count += 1
+
+        state.updated_at = _now()
+        if count == 0:
+            return _ok(state, f"{char.name} has no daily spells to recharge.")
+        return _ok(state, f"Recharged {count} daily spell(s) for {char.name}.")
+
     def remove_item(
         self,
         state: GameState,

--- a/engine/session.py
+++ b/engine/session.py
@@ -100,6 +100,24 @@ class SessionManager:
         if state.current_turn:
             state.current_turn.mode = SessionMode.EXPLORATION
             state.current_turn.turn_number = resumed_at
+        # Restore encounter-period spell charges for all characters.
+        from engine.azure_constants import RechargePeriod
+        from engine.data_loader import ITEM_REGISTRY
+        from engine.item import ChargeWeapon, UtilitySpell
+        for char in state.characters.values():
+            for inv_item in char.inventory:
+                if inv_item.charges is None:
+                    continue
+                defn = ITEM_REGISTRY.get(inv_item.item_id)
+                if defn is None:
+                    continue
+                if not isinstance(defn, (ChargeWeapon, UtilitySpell)):
+                    continue
+                if getattr(defn, "rechargePeriod", None) != RechargePeriod.ENCOUNTER:
+                    continue
+                if defn.maxCharges < 0:
+                    continue
+                inv_item.charges = defn.maxCharges
         state.updated_at = _now()
         return _ok(state, "Returning to exploration.")
 

--- a/tests/test_charges.py
+++ b/tests/test_charges.py
@@ -1,0 +1,265 @@
+"""
+tests/test_charges.py — ChargeWeapon / UtilitySpell recharge logic.
+
+Covers:
+  - exit_rounds() auto-restores ENCOUNTER-period spells
+  - exit_rounds() does NOT restore DAY-period spells
+  - adjust_spell_charges() clamps correctly
+  - recharge_day_spells() restores only DAY spells
+  - Charge state survives persistence round-trip
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from engine import (
+    adjust_spell_charges,
+    create_character,
+    enter_rounds,
+    exit_rounds,
+    give_item,
+    recharge_day_spells,
+    start_session,
+)
+from engine.azure_constants import RechargePeriod
+from engine.data_loader import ITEM_REGISTRY
+from engine.item import ChargeWeapon, UtilitySpell
+from models import CharacterClass, GameState, InventoryItem, Party, SessionMode
+from persistence import Database
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_state() -> GameState:
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+    create_character(state, "Mira", CharacterClass.MAGE, "Pack A", owner_id="u1")
+    start_session(state)
+    return state
+
+
+def _char(state: GameState):
+    return next(iter(state.characters.values()))
+
+
+def _find_encounter_spell():
+    """Return an item_id for an ENCOUNTER-period ChargeWeapon in the registry."""
+    for iid, defn in ITEM_REGISTRY.items():
+        if (isinstance(defn, ChargeWeapon)
+                and defn.rechargePeriod == RechargePeriod.ENCOUNTER
+                and defn.maxCharges > 0):
+            return iid
+    return None
+
+
+def _find_day_spell():
+    """Return an item_id for a DAY-period ChargeWeapon in the registry."""
+    for iid, defn in ITEM_REGISTRY.items():
+        if (isinstance(defn, ChargeWeapon)
+                and defn.rechargePeriod == RechargePeriod.DAY
+                and defn.maxCharges > 0):
+            return iid
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Encounter recharge via exit_rounds
+# ---------------------------------------------------------------------------
+
+class TestEncounterRecharge:
+
+    def test_encounter_spell_restored_on_exit_rounds(self):
+        spell_id = _find_encounter_spell()
+        if spell_id is None:
+            pytest.skip("No ENCOUNTER ChargeWeapon in registry.")
+
+        state = _make_state()
+        char = _char(state)
+        give_item(state, char.character_id, spell_id)
+
+        # Drain all charges manually.
+        inv = next(i for i in char.inventory if i.item_id == spell_id)
+        inv.charges = 0
+
+        enter_rounds(state)
+        exit_rounds(state)
+
+        inv = next(i for i in char.inventory if i.item_id == spell_id)
+        defn = ITEM_REGISTRY[spell_id]
+        assert inv.charges == defn.maxCharges
+
+    def test_day_spell_not_restored_on_exit_rounds(self):
+        spell_id = _find_day_spell()
+        if spell_id is None:
+            pytest.skip("No DAY ChargeWeapon in registry.")
+
+        state = _make_state()
+        char = _char(state)
+        give_item(state, char.character_id, spell_id)
+
+        inv = next(i for i in char.inventory if i.item_id == spell_id)
+        inv.charges = 0
+
+        enter_rounds(state)
+        exit_rounds(state)
+
+        inv = next(i for i in char.inventory if i.item_id == spell_id)
+        assert inv.charges == 0
+
+
+# ---------------------------------------------------------------------------
+# adjust_spell_charges
+# ---------------------------------------------------------------------------
+
+class TestAdjustSpellCharges:
+
+    def _setup_spell(self, max_charges: int = 3, recharge: RechargePeriod = RechargePeriod.DAY):
+        """Directly inject an InventoryItem with known charge data into a character."""
+        state = _make_state()
+        char = _char(state)
+
+        # Find any real ChargeWeapon from registry to use as definition.
+        spell_id = None
+        for iid, defn in ITEM_REGISTRY.items():
+            if (isinstance(defn, ChargeWeapon)
+                    and defn.maxCharges == max_charges
+                    and defn.rechargePeriod == recharge):
+                spell_id = iid
+                break
+
+        if spell_id is None:
+            # Fall back to any DAY spell and patch our test around its real maxCharges.
+            spell_id = _find_day_spell()
+            if spell_id is None:
+                pytest.skip("No suitable ChargeWeapon in registry.")
+
+        give_item(state, char.character_id, spell_id)
+        inv = next(i for i in char.inventory if i.item_id == spell_id)
+        defn = ITEM_REGISTRY[spell_id]
+        return state, char, inv, defn
+
+    def test_positive_delta_adds_charges(self):
+        state, char, inv, defn = self._setup_spell()
+        inv.charges = 0
+        result = adjust_spell_charges(state, char.character_id, defn.item_id, delta=1)
+        assert result.ok
+        inv = next(i for i in char.inventory if i.item_id == defn.item_id)
+        assert inv.charges == 1
+
+    def test_negative_delta_removes_charges(self):
+        state, char, inv, defn = self._setup_spell()
+        inv.charges = defn.maxCharges
+        result = adjust_spell_charges(state, char.character_id, defn.item_id, delta=-1)
+        assert result.ok
+        inv = next(i for i in char.inventory if i.item_id == defn.item_id)
+        assert inv.charges == defn.maxCharges - 1
+
+    def test_clamps_above_max(self):
+        state, char, inv, defn = self._setup_spell()
+        inv.charges = defn.maxCharges
+        adjust_spell_charges(state, char.character_id, defn.item_id, delta=9999)
+        inv = next(i for i in char.inventory if i.item_id == defn.item_id)
+        assert inv.charges == defn.maxCharges
+
+    def test_clamps_below_zero(self):
+        state, char, inv, defn = self._setup_spell()
+        inv.charges = 0
+        adjust_spell_charges(state, char.character_id, defn.item_id, delta=-9999)
+        inv = next(i for i in char.inventory if i.item_id == defn.item_id)
+        assert inv.charges == 0
+
+    def test_infinite_spell_rejected(self):
+        state = _make_state()
+        char = _char(state)
+        # Find an infinite-charge spell.
+        spell_id = None
+        for iid, defn in ITEM_REGISTRY.items():
+            if isinstance(defn, ChargeWeapon) and defn.maxCharges < 0:
+                spell_id = iid
+                break
+        if spell_id is None:
+            pytest.skip("No INFINITE ChargeWeapon in registry.")
+        give_item(state, char.character_id, spell_id)
+        result = adjust_spell_charges(state, char.character_id, spell_id, delta=1)
+        assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# recharge_day_spells
+# ---------------------------------------------------------------------------
+
+class TestRechargeDaySpells:
+
+    def test_recharges_only_day_spells(self):
+        enc_id = _find_encounter_spell()
+        day_id = _find_day_spell()
+        if enc_id is None or day_id is None:
+            pytest.skip("Need both ENCOUNTER and DAY spells in registry.")
+
+        state = _make_state()
+        char = _char(state)
+        give_item(state, char.character_id, enc_id)
+        give_item(state, char.character_id, day_id)
+
+        # Drain both.
+        for inv in char.inventory:
+            if inv.item_id in (enc_id, day_id):
+                inv.charges = 0
+
+        result = recharge_day_spells(state, char.character_id)
+        assert result.ok
+
+        enc_inv = next(i for i in char.inventory if i.item_id == enc_id)
+        day_inv = next(i for i in char.inventory if i.item_id == day_id)
+        assert enc_inv.charges == 0
+        assert day_inv.charges == ITEM_REGISTRY[day_id].maxCharges
+
+    def test_returns_ok_when_no_day_spells(self):
+        state = _make_state()
+        char = _char(state)
+        result = recharge_day_spells(state, char.character_id)
+        assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip
+# ---------------------------------------------------------------------------
+
+class TestChargePersistence:
+
+    def test_charges_survive_save_and_load(self):
+        spell_id = _find_day_spell()
+        if spell_id is None:
+            pytest.skip("No DAY ChargeWeapon in registry.")
+
+        state = _make_state()
+        char = _char(state)
+        give_item(state, char.character_id, spell_id)
+
+        inv = next(i for i in char.inventory if i.item_id == spell_id)
+        inv.charges = 1  # deliberately partial
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            db = Database(db_path)
+            db.save(state)
+            loaded = db.load("ch")
+            db.close()
+        finally:
+            os.unlink(db_path)
+
+        assert loaded is not None
+        loaded_char = next(iter(loaded.characters.values()))
+        loaded_inv = next((i for i in loaded_char.inventory if i.item_id == spell_id), None)
+        assert loaded_inv is not None
+        assert loaded_inv.charges == 1

--- a/tests/test_charges.py
+++ b/tests/test_charges.py
@@ -11,7 +11,6 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 import tempfile
@@ -31,8 +30,8 @@ from engine import (
 )
 from engine.azure_constants import RechargePeriod
 from engine.data_loader import ITEM_REGISTRY
-from engine.item import ChargeWeapon, UtilitySpell
-from models import CharacterClass, GameState, InventoryItem, Party, SessionMode
+from engine.item import ChargeWeapon
+from models import CharacterClass, GameState, Party
 from persistence import Database
 
 # ---------------------------------------------------------------------------

--- a/webui/app.py
+++ b/webui/app.py
@@ -23,6 +23,7 @@ import store
 from discord_tasks import dispatch_oracle_answer, dispatch_turn_resolved, drain_level_ups
 from engine import (
     add_exit,
+    adjust_spell_charges,
     answer_oracle,
     apply_condition,
     award_xp,
@@ -35,6 +36,7 @@ from engine import (
     import_dungeon,
     move_party_to_room,
     open_turn,
+    recharge_day_spells,
     register_room,
     remove_item,
     remove_npc,
@@ -426,6 +428,22 @@ async def route_party_addxp(
         asyncio.create_task(drain_level_ups(_bot, state))
     each = amount // n if n else 0
     return _respond(channel_id, flash=f"Distributed {amount} XP among {n} active characters ({each} each).")
+
+
+@app.post("/session/{channel_id}/party/rechargedaily", response_class=HTMLResponse)
+async def route_party_rechargedaily(channel_id: str):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    if state.party is None:
+        return _respond(channel_id, error="No party.")
+    count = 0
+    for char in state.characters.values():
+        result = recharge_day_spells(state, char.character_id)
+        if result.ok and "no daily" not in result.message:
+            count += 1
+    await save_session_async(state)
+    return _respond(channel_id, flash=f"Recharged daily spells for {count} character(s).")
 
 
 # ---------------------------------------------------------------------------
@@ -1162,5 +1180,50 @@ async def route_character_addxp(
     sync_character_to_sessions(char)
     if _bot:
         asyncio.create_task(drain_level_ups(_bot, state))
+    return _char_redirect(char_id, flash=result.message)
+
+
+@app.post("/characters/{char_id}/spellcharge", response_class=HTMLResponse)
+async def route_character_spellcharge(
+    char_id: str,
+    item_id: Annotated[str, Form()],
+    delta: Annotated[int, Form()],
+):
+    state, char = _load_char_state(char_id)
+    if char is None:
+        return _char_redirect(char_id, error="Character not found.")
+    result = adjust_spell_charges(state, char.character_id, item_id, delta)
+    if not result.ok:
+        return _char_redirect(char_id, error=result.error)
+    await store.db.save_character_async(char)
+    sync_character_to_sessions(char)
+    return _char_redirect(char_id, flash=result.message)
+
+
+@app.post("/characters/{char_id}/spellrecharge", response_class=HTMLResponse)
+async def route_character_spellrecharge(
+    char_id: str,
+    item_id: Annotated[str, Form()],
+):
+    state, char = _load_char_state(char_id)
+    if char is None:
+        return _char_redirect(char_id, error="Character not found.")
+    # Use a large positive delta; adjust_spell_charges clamps to maxCharges.
+    result = adjust_spell_charges(state, char.character_id, item_id, delta=9999)
+    if not result.ok:
+        return _char_redirect(char_id, error=result.error)
+    await store.db.save_character_async(char)
+    sync_character_to_sessions(char)
+    return _char_redirect(char_id, flash=result.message)
+
+
+@app.post("/characters/{char_id}/rechargedaily", response_class=HTMLResponse)
+async def route_character_rechargedaily(char_id: str):
+    state, char = _load_char_state(char_id)
+    if char is None:
+        return _char_redirect(char_id, error="Character not found.")
+    result = recharge_day_spells(state, char.character_id)
+    await store.db.save_character_async(char)
+    sync_character_to_sessions(char)
     return _char_redirect(char_id, flash=result.message)
 

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import html as _html
 
-from engine.azure_constants import XP_THRESHOLDS
+from engine.azure_constants import RechargePeriod, XP_THRESHOLDS
 from engine.character import CharacterManager
 from engine.data_loader import ITEM_REGISTRY
+from engine.item import ChargeWeapon, UtilitySpell
 from models import (
     Character,
     CharacterStatus,
@@ -786,6 +787,10 @@ def party_panel(state: GameState) -> str:
       <button type="submit">Distribute XP</button>
     </div>
   </form>
+  <form hx-post="/session/{channel_id}/party/rechargedaily"
+        hx-target="#dashboard" hx-swap="outerHTML" style="margin-bottom:0.5rem">
+    <button type="submit">Recharge All Daily Spells</button>
+  </form>
   <table>
     <tr><th>Character</th><th>HP</th><th>Status</th><th>Controls</th></tr>
     {rows}
@@ -1502,6 +1507,42 @@ def character_sheet_panel(character: Character) -> str:
         if _ci.container_id:
             _contained_map.setdefault(_ci.container_id, []).append(_ci)
 
+    def _recharge_tag(period) -> str:
+        """Return a small [D] or [E] pill for DAY/ENCOUNTER spells; empty string otherwise."""
+        if period == RechargePeriod.DAY:
+            return ' <span class="muted" style="font-size:0.7rem;border:1px solid #555;border-radius:3px;padding:0 3px" title="Daily recharge">D</span>'
+        if period == RechargePeriod.ENCOUNTER:
+            return ' <span class="muted" style="font-size:0.7rem;border:1px solid #555;border-radius:3px;padding:0 3px" title="Encounter recharge">E</span>'
+        return ""
+
+    def _charge_controls(item_id: str, charges: int | None, max_charges: int, recharge_period=None) -> str:
+        """Return inline charge badge + +/- and restore buttons for finite-charge spells."""
+        if charges is None or max_charges < 0:
+            return ""
+        badge = f'<span class="muted" style="font-size:0.8rem">({charges}/{max_charges})</span>'
+        period_tag = _recharge_tag(recharge_period)
+        minus_form = (
+            f'<form method="post" action="/characters/{cid_str}/spellcharge" style="margin:0;display:inline">'
+            f'<input type="hidden" name="item_id" value="{item_id}">'
+            f'<input type="hidden" name="delta" value="-1">'
+            f'<button class="btn-sm" type="submit" style="padding:1px 5px">−</button>'
+            f'</form>'
+        )
+        plus_form = (
+            f'<form method="post" action="/characters/{cid_str}/spellcharge" style="margin:0;display:inline">'
+            f'<input type="hidden" name="item_id" value="{item_id}">'
+            f'<input type="hidden" name="delta" value="1">'
+            f'<button class="btn-sm" type="submit" style="padding:1px 5px">+</button>'
+            f'</form>'
+        )
+        restore_form = (
+            f'<form method="post" action="/characters/{cid_str}/spellrecharge" style="margin:0;display:inline">'
+            f'<input type="hidden" name="item_id" value="{item_id}">'
+            f'<button class="btn-sm" type="submit" style="padding:1px 5px" title="Restore to max">↺</button>'
+            f'</form>'
+        )
+        return f' {badge}{period_tag} {minus_form}{plus_form}{restore_form}'
+
     item_rows = ""
     for inv_item in character.inventory:
         if inv_item.container_id:
@@ -1510,9 +1551,22 @@ def character_sheet_panel(character: Character) -> str:
         item_name = defn.name if defn else inv_item.item_id
         qty_str = f'<span class="muted"> ×{inv_item.quantity}</span>' if inv_item.quantity > 1 else ""
         equip_str = ' <span class="tag tag-open" style="font-size:0.7rem;padding:1px 5px">equip</span>' if inv_item.equipped else ""
+        # Show charge controls for standalone ChargeWeapons with finite charges.
+        standalone_charges = ""
+        if (isinstance(defn, ChargeWeapon)
+                and inv_item.charges is not None
+                and defn.maxCharges >= 0):
+            standalone_charges = _charge_controls(
+                inv_item.item_id, inv_item.charges, defn.maxCharges,
+                recharge_period=defn.rechargePeriod,
+            )
+        elif (isinstance(defn, ChargeWeapon)
+              and inv_item.charges is not None
+              and defn.maxCharges < 0):
+            standalone_charges = ' <span class="muted" style="font-size:0.8rem">(∞)</span>'
         item_rows += (
             f'<tr>'
-            f'<td>{item_name}{qty_str}{equip_str}</td>'
+            f'<td>{item_name}{qty_str}{equip_str}{standalone_charges}</td>'
             f'<td style="width:1%;white-space:nowrap">'
             f'<form method="post" action="/characters/{cid_str}/removeitem" style="margin:0">'
             f'<input type="hidden" name="item_id" value="{inv_item.item_id}">'
@@ -1525,16 +1579,20 @@ def character_sheet_panel(character: Character) -> str:
         for _child in _contained_map.get(inv_item.item_id, []):
             _cdefn = ITEM_REGISTRY.get(_child.item_id)
             _cname = _cdefn.name if _cdefn else _child.item_id
-            _charges_str = ""
             if _child.charges is not None and _cdefn is not None and hasattr(_cdefn, "maxCharges"):
                 if _cdefn.maxCharges < 0:
-                    _charges_str = ' <span class="muted" style="font-size:0.8rem">(∞)</span>'
+                    _charges_display = ' <span class="muted" style="font-size:0.8rem">(∞)</span>'
                 else:
-                    _charges_str = f' <span class="muted" style="font-size:0.8rem">({_child.charges}/{_cdefn.maxCharges})</span>'
+                    _charges_display = _charge_controls(
+                        _child.item_id, _child.charges, _cdefn.maxCharges,
+                        recharge_period=getattr(_cdefn, "rechargePeriod", None),
+                    )
+            else:
+                _charges_display = ""
             item_rows += (
-                f'<tr style="opacity:0.7">'
+                f'<tr style="opacity:0.85">'
                 f'<td style="padding-left:1.5rem;font-size:0.9rem">'
-                f'<span class="muted">└</span> {_cname}{_charges_str}'
+                f'<span class="muted">└</span> {_cname}{_charges_display}'
                 f'</td>'
                 f'<td></td>'
                 f'</tr>'
@@ -1602,6 +1660,11 @@ def character_sheet_panel(character: Character) -> str:
       <button type="submit">Add item</button>
     </div>
   </form>
+  <div style="margin-top:0.5rem">
+    <form method="post" action="/characters/{cid_str}/rechargedaily" style="margin:0;display:inline">
+      <button class="btn-sm" type="submit">Recharge All (Day)</button>
+    </form>
+  </div>
 
   <hr class="divider">
 

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 import html as _html
 
-from engine.azure_constants import RechargePeriod, XP_THRESHOLDS
+from engine.azure_constants import XP_THRESHOLDS, RechargePeriod
 from engine.character import CharacterManager
 from engine.data_loader import ITEM_REGISTRY
-from engine.item import ChargeWeapon, UtilitySpell
+from engine.item import ChargeWeapon
 from models import (
     Character,
     CharacterStatus,


### PR DESCRIPTION
Resolves #65. exit_rounds() now recharges all encounter-based spell recharges. UI buttons allow the DM to manually adjust daily-recharge spell charges, or recharge all of a character's daily charges.