### PR TITLE
fix: equip a single item from stack

### DIFF
--- a/engine/character.py
+++ b/engine/character.py
@@ -41,13 +41,13 @@ def _projected_slots_used_after_equip(
     unequipped→equipped and every ID in ``displace_item_ids`` moves from
     equipped→unequipped.
 
-    Uses bundle-aware math so light-item stacks are accounted for correctly.
+    Uses bundle-aware math so light-weight-item stacks are accounted for correctly.
     """
     from math import ceil
 
     from engine.azure_constants import BUNDLE_SIZE
 
-    # Current unequipped light total and derived non-light slots
+    # Current unequipped light-weight total and derived non-light-weight slots
     L = sum(
         i.quantity
         for i in char.inventory
@@ -414,7 +414,7 @@ class CharacterManager:
                 char.equipped_slots[ItemSlot.OFF_HAND.value] = None
                 extra_msg = f" (Two-Handed: {oh_name} unequipped from off-hand.)"
 
-        # Initialise light charges at equip time
+        # Initialise light-emitting charges at equip time
         if getattr(definition, "max_light_turns", None) is not None:
             if definition.isLight and inv_item.quantity > 1:
                 # Split one torch out of the bundle
@@ -440,6 +440,13 @@ class CharacterManager:
                 else:
                     inv_item.charges = definition.max_light_turns  # torch: set full charges
             # else charges > 0: mid-burn item re-equipped → keep existing charges
+        elif inv_item.quantity > 1:
+            # Non-light-emitting stackable item: split one unit off before equipping
+            inv_item.quantity -= 1
+            from models import InventoryItem as _InvItem
+            split = _InvItem(item_id=item_id, quantity=1)
+            char.inventory.append(split)
+            inv_item = split
 
         # Equip the new item
         inv_item.equipped = True
@@ -460,8 +467,8 @@ class CharacterManager:
         enforcing the inventory slot limit.
 
         Stacking rules:
-        - Light items (is_light=True) are bundled BUNDLE_SIZE-per-slot across
-          all light item types; the capacity check uses bundle math.
+        - Light-weight items (is_light=True) are bundled BUNDLE_SIZE-per-slot across
+          all light-weight item types; the capacity check uses bundle math.
         - ChargeWeapons are never stacked (each has independent charge state);
           a new InventoryItem entry is always created.
         - All other items stack onto an existing unequipped entry if one
@@ -483,7 +490,7 @@ class CharacterManager:
         slot_cost = defn.slot_cost
 
         if defn.isLight:
-            # Bundle-aware capacity check: all light items share bundle slots.
+            # Bundle-aware capacity check: all light-weight items share bundle slots.
             current_light = sum(
                 i.quantity for i in char.inventory
                 if not i.equipped
@@ -632,7 +639,7 @@ class CharacterManager:
             None,
         )
         if inv_item is None:
-            return _err(state, f"No light item '{item_id}' with charges found on {char.name}.")
+            return _err(state, f"No light-emitting item '{item_id}' with charges found on {char.name}.")
 
         defn = ITEM_REGISTRY.get(item_id)
         if defn is None or getattr(defn, "max_light_turns", None) is None:
@@ -754,8 +761,9 @@ class CharacterManager:
         definition = ITEM_REGISTRY.get(item_id)
         item_name = definition.name if definition else item_id
 
-        # Bundle-aware pre-flight: unequipping a light item may push the light pool
-        # across a BUNDLE_SIZE boundary, costing an extra inventory slot.
+        # Bundle-aware pre-flight: unequipping a light-weight item may push the
+        # light pool across a BUNDLE_SIZE boundary, costing an extra inventory
+        # slot.
         if inv_item and definition is not None and definition.isLight:
             from math import ceil
 

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -671,6 +671,50 @@ class TestEquipErrors:
 
 
 # ---------------------------------------------------------------------------
+# Stack-splitting on equip
+# ---------------------------------------------------------------------------
+
+class TestEquipStackSplit:
+    def test_equip_splits_stack_of_non_light_items(self, state_char):
+        """Equipping one item from a stack of N should leave N-1 unequipped and 1 equipped."""
+        _ARCANE = {"V", "W", "X", "Y", "Z"}
+        weapon_id = next(
+            item_id for item_id, defn in ITEM_REGISTRY.items()
+            if isinstance(defn, Weapon) and not isinstance(defn, ChargeWeapon)
+            and defn.rank not in _ARCANE
+        )
+        char = _get_char(state_char)
+        char.inventory.append(InventoryItem(item_id=weapon_id, quantity=3))
+
+        equip_item(state_char, char.character_id, weapon_id)
+
+        weapon_entries = [i for i in char.inventory if i.item_id == weapon_id]
+        assert len(weapon_entries) == 2, "Stack should split into two entries"
+        equipped = [i for i in weapon_entries if i.equipped]
+        unequipped = [i for i in weapon_entries if not i.equipped]
+        assert len(equipped) == 1 and equipped[0].quantity == 1
+        assert len(unequipped) == 1 and unequipped[0].quantity == 2
+
+    def test_equip_single_item_no_split(self, state_char):
+        """Equipping a stack of 1 should not create a spurious empty entry."""
+        _ARCANE = {"V", "W", "X", "Y", "Z"}
+        weapon_id = next(
+            item_id for item_id, defn in ITEM_REGISTRY.items()
+            if isinstance(defn, Weapon) and not isinstance(defn, ChargeWeapon)
+            and defn.rank not in _ARCANE
+        )
+        char = _get_char(state_char)
+        char.inventory.append(InventoryItem(item_id=weapon_id, quantity=1))
+
+        equip_item(state_char, char.character_id, weapon_id)
+
+        weapon_entries = [i for i in char.inventory if i.item_id == weapon_id]
+        assert len(weapon_entries) == 1, "No split should occur for a single-item stack"
+        assert weapon_entries[0].equipped is True
+        assert weapon_entries[0].quantity == 1
+
+
+# ---------------------------------------------------------------------------
 # Serialization round-trip
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Added an elif inv_item.quantity > 1 branch after the max_light_turns block (line 443). When a non-light item is equipped from a stack, it decrements the original entry and appends a new
InventoryItem(quantity=1) that gets marked equipped. This mirrors the existing light-split pattern exactly.