### PR TITLE
fix: add instance identifier for InventoryItem

### DIFF
--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -121,7 +121,7 @@ def _character_sheet(char, state) -> str:
             _light_charges = f" ({i.charges}/{defn.max_light_turns})"
         line = f"  {i.quantity}x {i.definition.name}{_light_charges}{'  [equipped]' if i.equipped else ''}"
         _inv_parts.append(line)
-        for _child in _contained.get(i.item_id, []):
+        for _child in _contained.get(i.instance_id, []):
             _cdefn = ITEM_REGISTRY.get(_child.item_id)
             _cname = _cdefn.name if _cdefn else _child.item_id
             _period = getattr(_cdefn, "rechargePeriod", None)

--- a/engine/character.py
+++ b/engine/character.py
@@ -538,7 +538,8 @@ class CharacterManager:
                     f"({char.slots_used}/{char.inventory_size} slots used).",
                 )
             for _ in range(quantity):
-                char.inventory.append(InventoryItem(item_id=item_id, quantity=1))
+                container_inv = InventoryItem(item_id=item_id, quantity=1)
+                char.inventory.append(container_inv)
                 # Add each contained spell as its own InventoryItem with per-character charges.
                 for spell_id in defn.contained_item_ids:
                     spell_def = ITEM_REGISTRY.get(spell_id)
@@ -546,7 +547,7 @@ class CharacterManager:
                     char.inventory.append(InventoryItem(
                         item_id=spell_id,
                         quantity=1,
-                        container_id=item_id,
+                        container_id=container_inv.instance_id,
                         charges=spell_charges,
                     ))
 
@@ -731,7 +732,7 @@ class CharacterManager:
             char.inventory.remove(inv_item)
             # Purge any items that were contained inside this container.
             if isinstance(defn, ContainerItem):
-                char.inventory = [i for i in char.inventory if i.container_id != item_id]
+                char.inventory = [i for i in char.inventory if i.container_id != inv_item.instance_id]
 
         state.updated_at = _now()
         qty_str = f"{quantity}x " if quantity > 1 else ""

--- a/models.py
+++ b/models.py
@@ -135,7 +135,8 @@ class InventoryItem:
     broken:       bool   = False
     charges:      int | None = None
     notes:        str    = ""
-    container_id: str | None = None   # item_id of owning ContainerItem, if any
+    container_id: str | None = None   # instance_id of owning ContainerItem, if any
+    instance_id:  str    = field(default_factory=lambda: __import__("uuid").uuid4().hex)
 
     @property
     def definition(self):

--- a/scripts/equipment_table.py
+++ b/scripts/equipment_table.py
@@ -10,7 +10,6 @@ Usage:
 """
 
 import json
-import math
 import re
 from pathlib import Path
 

--- a/serialization.py
+++ b/serialization.py
@@ -72,6 +72,7 @@ def serialize_inventory_item(item: InventoryItem) -> dict:
         "charges":      item.charges,
         "notes":        item.notes,
         "container_id": item.container_id,
+        "instance_id":  item.instance_id,
     }
 
 
@@ -365,6 +366,7 @@ def _load_dt(v) -> datetime | None:
 
 
 def deserialize_inventory_item(d: dict) -> InventoryItem:
+    import uuid as _uuid
     return InventoryItem(
         item_id=d["item_id"],
         quantity=d.get("quantity", 1),
@@ -373,6 +375,7 @@ def deserialize_inventory_item(d: dict) -> InventoryItem:
         charges=d.get("charges"),
         notes=d.get("notes", ""),
         container_id=d.get("container_id"),
+        instance_id=d.get("instance_id") or _uuid.uuid4().hex,
     )
 
 

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -794,11 +794,12 @@ class TestSpellbookChargeTracking:
         char = _get_char(state_mage)
         give_item(state_mage, char.character_id, spellbook_id)
 
+        book_inv = next(i for i in char.inventory if i.item_id == spellbook_id)
         book_def = ITEM_REGISTRY[spellbook_id]
         for spell_id in book_def.contained_item_ids:
             spell_inv = next(
                 (i for i in char.inventory
-                 if i.item_id == spell_id and i.container_id == spellbook_id),
+                 if i.item_id == spell_id and i.container_id == book_inv.instance_id),
                 None,
             )
             assert spell_inv is not None, f"Spell {spell_id} not added to inventory"
@@ -811,11 +812,13 @@ class TestSpellbookChargeTracking:
         char = _get_char(state_mage)
         give_item(state_mage, char.character_id, spellbook_id)
 
+        book_inv = next(i for i in char.inventory if i.item_id == spellbook_id)
+        book_instance_id = book_inv.instance_id
         book_def = ITEM_REGISTRY[spellbook_id]
         # Verify spells are present before removal
         for spell_id in book_def.contained_item_ids:
             assert any(
-                i.item_id == spell_id and i.container_id == spellbook_id
+                i.item_id == spell_id and i.container_id == book_instance_id
                 for i in char.inventory
             )
 
@@ -825,9 +828,49 @@ class TestSpellbookChargeTracking:
         assert not any(i.item_id == spellbook_id for i in char.inventory)
         for spell_id in book_def.contained_item_ids:
             assert not any(
-                i.item_id == spell_id and i.container_id == spellbook_id
+                i.item_id == spell_id and i.container_id == book_instance_id
                 for i in char.inventory
             )
+
+    def test_give_two_spellbooks_no_duplicate_spells(self, state_mage, spellbook_id):
+        assert spellbook_id is not None, "No ContainerItem found in ITEM_REGISTRY"
+        char = _get_char(state_mage)
+        give_item(state_mage, char.character_id, spellbook_id)
+        give_item(state_mage, char.character_id, spellbook_id)
+
+        book_def = ITEM_REGISTRY[spellbook_id]
+        expected_spell_count = len(book_def.contained_item_ids) * 2
+        actual_spell_count = sum(1 for i in char.inventory if i.container_id is not None)
+        assert actual_spell_count == expected_spell_count, (
+            f"Expected {expected_spell_count} contained spells, got {actual_spell_count}"
+        )
+
+        # Each book instance must have its own independent set of contained spells.
+        books = [i for i in char.inventory if i.item_id == spellbook_id]
+        assert len(books) == 2
+        for book in books:
+            children = [i for i in char.inventory if i.container_id == book.instance_id]
+            assert len(children) == len(book_def.contained_item_ids), (
+                f"Book {book.instance_id} has {len(children)} spells, "
+                f"expected {len(book_def.contained_item_ids)}"
+            )
+
+    def test_remove_one_spellbook_leaves_other_intact(self, state_mage, spellbook_id):
+        assert spellbook_id is not None, "No ContainerItem found in ITEM_REGISTRY"
+        char = _get_char(state_mage)
+        give_item(state_mage, char.character_id, spellbook_id)
+        give_item(state_mage, char.character_id, spellbook_id)
+
+        books = [i for i in char.inventory if i.item_id == spellbook_id]
+        kept_instance_id = books[1].instance_id
+        book_def = ITEM_REGISTRY[spellbook_id]
+
+        remove_item(state_mage, char.character_id, spellbook_id)
+
+        # One book and its spells remain
+        assert sum(1 for i in char.inventory if i.item_id == spellbook_id) == 1
+        remaining_spells = [i for i in char.inventory if i.container_id == kept_instance_id]
+        assert len(remaining_spells) == len(book_def.contained_item_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -889,11 +932,12 @@ class TestUtilitySpellbookGive:
         char = _get_char(state_mage)
         give_item(state_mage, char.character_id, utility_spellbook_id)
 
+        book_inv = next(i for i in char.inventory if i.item_id == utility_spellbook_id)
         book_def = ITEM_REGISTRY[utility_spellbook_id]
         for spell_id in book_def.contained_item_ids:
             spell_inv = next(
                 (i for i in char.inventory
-                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                 if i.item_id == spell_id and i.container_id == book_inv.instance_id),
                 None,
             )
             assert spell_inv is not None, f"Spell {spell_id} not added to inventory"
@@ -907,15 +951,16 @@ class TestUtilitySpellbookGive:
         char = _get_char(state_mage)
         give_item(state_mage, char.character_id, utility_spellbook_id)
 
+        book_inv = next(i for i in char.inventory if i.item_id == utility_spellbook_id)
         book_def = ITEM_REGISTRY[utility_spellbook_id]
         for spell_id in book_def.contained_item_ids:
             spell_inv = next(
                 (i for i in char.inventory
-                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                 if i.item_id == spell_id and i.container_id == book_inv.instance_id),
                 None,
             )
             assert spell_inv is not None
-            assert spell_inv.container_id == utility_spellbook_id
+            assert spell_inv.container_id == book_inv.instance_id
             assert not spell_inv.equipped
 
 
@@ -930,6 +975,8 @@ class TestUtilitySpellCharacterSheet:
         char = _get_char(state_mage)
         give_item(state_mage, char.character_id, utility_spellbook_id)
 
+        book_inv = next(i for i in char.inventory if i.item_id == utility_spellbook_id)
+
         # Build the same contained-item lines that _character_sheet produces.
         contained: dict[str, list] = {}
         for inv in char.inventory:
@@ -937,7 +984,7 @@ class TestUtilitySpellCharacterSheet:
                 contained.setdefault(inv.container_id, []).append(inv)
 
         lines = []
-        for child in contained.get(utility_spellbook_id, []):
+        for child in contained.get(book_inv.instance_id, []):
             cdefn = ITEM_REGISTRY.get(child.item_id)
             cname = cdefn.name if cdefn else child.item_id
             if child.charges is not None and cdefn is not None and hasattr(cdefn, "maxCharges"):
@@ -968,18 +1015,20 @@ class TestUtilitySpellPersistence:
         restored = deserialize_state(serialize_state(state_mage))
         rest_char = next(iter(restored.characters.values()))
 
+        book_inv = next(i for i in char.inventory if i.item_id == utility_spellbook_id)
+        book_instance_id = book_inv.instance_id
         book_def = ITEM_REGISTRY[utility_spellbook_id]
         for spell_id in book_def.contained_item_ids:
             orig = next(
                 (i for i in char.inventory
-                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                 if i.item_id == spell_id and i.container_id == book_instance_id),
                 None,
             )
             restored_inv = next(
                 (i for i in rest_char.inventory
-                 if i.item_id == spell_id and i.container_id == utility_spellbook_id),
+                 if i.item_id == spell_id and i.container_id == book_instance_id),
                 None,
             )
             assert restored_inv is not None, f"Spell {spell_id} lost after round-trip"
             assert restored_inv.charges == orig.charges
-            assert restored_inv.container_id == utility_spellbook_id
+            assert restored_inv.container_id == book_instance_id

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -1592,7 +1592,7 @@ def character_sheet_panel(character: Character) -> str:
             f'</td>'
             f'</tr>'
         )
-        for _child in _contained_map.get(inv_item.item_id, []):
+        for _child in _contained_map.get(inv_item.instance_id, []):
             _cdefn = ITEM_REGISTRY.get(_child.item_id)
             _cname = _cdefn.name if _cdefn else _child.item_id
             if _child.charges is not None and _cdefn is not None and hasattr(_cdefn, "maxCharges"):


### PR DESCRIPTION
Resolves #111. In order to properly determine which container an item belongs to when there are multiple containers, InventoryItem instances need unique instance IDs. Container spells now reference parent instance_id instead of item_id.