### PR TITLE
fix: add NPC button refers to current room

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -193,10 +193,10 @@ def recharge_day_spells(state: GameState, character_id):
     return cm.recharge_day_spells(state, character_id)
 
 
-def add_npc(state: GameState, npc):
+def add_npc(state: GameState, npc, room_id=None):
     """Add an NPC."""
     nm = NPCManager()
-    return nm.add_npc_to_room(state, npc)
+    return nm.add_npc_to_room(state, npc, room_id=room_id)
 
 
 def set_npc_hp(state: GameState, npc_id, new_hp: int):

--- a/webui/app.py
+++ b/webui/app.py
@@ -608,6 +608,7 @@ async def route_addnpc(
     description: Annotated[str, Form()] = "",
     notes: Annotated[str, Form()] = "",
     hidden: Annotated[bool, Form()] = False,
+    view_room_id: Annotated[str, Form()] = "",
 ):
     state = store.get_session(channel_id)
     if state is None:
@@ -619,8 +620,10 @@ async def route_addnpc(
         description=description, notes=notes,
         hidden=hidden,
     )
-    eng_add_npc(state, npc)
-    return _respond(channel_id)
+    room_id = UUID(view_room_id) if view_room_id else None
+    eng_add_npc(state, npc, room_id=room_id)
+    await save_session_async(state)
+    return _respond(channel_id, view_room_id=view_room_id)
 
 
 @app.post("/session/{channel_id}/npc/{npc_id}/sethp", response_class=HTMLResponse)

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -1306,6 +1306,7 @@ def npc_panel(
 <div class="section-header"><h3>Add NPC</h3></div>
 <form hx-post="/session/{channel_id}/addnpc"
       hx-target="#dashboard" hx-swap="outerHTML">
+  <input type="hidden" name="view_room_id" value="{view_room_id}">
   <div class="row">
     <div><label>Name</label><input type="text" name="name" placeholder="Goblin A"></div>
     <div><label>HP</label><input type="number" name="hp" value="4" min="1"></div>


### PR DESCRIPTION
Resolves #130. add_npc now accepts an optional room_id, webui code now resolves the current room to a room id and passes it to the engine, persists the session, and returns correct room view.