### PR TITLE
feat: implement actions/skills for jobs

### DIFF
--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -835,7 +835,10 @@ class ClassActionView(discord.ui.View):
 
             elif action_def.requires_target in ("allies", "enemies"):
                 if action_def.requires_target == "allies":
-                    combatant_targets = state.active_characters
+                    combatant_targets = [
+                        c for c in state.active_characters
+                        if c.character_id != owner_char.character_id
+                    ]
                 else:
                     combatant_targets = [
                         n for n in state.npcs_in_current_room

--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -815,7 +815,7 @@ class ClassActionView(discord.ui.View):
 
             if action_def.action_type == "affect":
                 await interaction.response.send_modal(
-                    AffectModal(char_id=self.char_id, channel_id=self.channel_id)
+                    AffectModal(char_id=self.char_id, channel_id=self.channel_id, action_id=action_id)
                 )
                 return
 
@@ -1202,10 +1202,13 @@ class AffectModal(discord.ui.Modal):
     which bypasses auto-resolution and hands the round to the DM.
     """
 
-    def __init__(self, char_id: UUID, channel_id: str) -> None:
-        super().__init__(title="Affect — Free Action", timeout=300)
+    def __init__(self, char_id: UUID, channel_id: str, action_id: str = "affect") -> None:
+        action_def = ACTION_REGISTRY.get(action_id)
+        title = f"{action_def.label} — Free Action" if action_def else "Affect — Free Action"
+        super().__init__(title=title, timeout=300)
         self.char_id    = char_id
         self.channel_id = channel_id
+        self.action_id  = action_id
 
         self.text = discord.ui.TextInput(
             label=get_string("ui.affect.label"),
@@ -1237,8 +1240,10 @@ class AffectModal(discord.ui.Modal):
             )
             return
 
-        action      = CombatAction(action_id="affect", free_text=self.text.value)
-        action_text = f"Affect: {self.text.value}"
+        action_def  = ACTION_REGISTRY.get(self.action_id)
+        label_str   = action_def.label if action_def else "Affect"
+        action      = CombatAction(action_id=self.action_id, free_text=self.text.value)
+        action_text = f"{label_str}: {self.text.value}"
         turn_number = state.turn_number
 
         result = submit_turn(

--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -188,7 +188,15 @@ def _character_sheet(char, state) -> str:
     if active_skills:
         skill_lines = []
         for skill in active_skills:
-            skill_lines.append(f"  {skill.name}: {skill.description}")
+            if skill.uses is not None:
+                job_exp = char.jobs.get(skill.source)
+                job_level = job_exp.level if job_exp else char.level
+                max_uses = CharacterManager.get_skill_max_uses(skill, job_level)
+                current = char.skill_uses.get(skill.skill_id, max_uses)
+                uses_str = f" [{current}/{max_uses} uses]"
+            else:
+                uses_str = ""
+            skill_lines.append(f" \u2023 {skill.name}{uses_str}: {skill.description}")
         sheet_lines.append("Skills:")
         sheet_lines.extend(skill_lines)
         sheet_lines.append(sep)

--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 import discord
 
-from engine import equip_item, unequip_item
+from engine import equip_item, set_familiar_weapon, unequip_item
 from engine.azure_constants import UI_SLOTS, ItemSlot, RechargePeriod
 from engine.character import CharacterManager
 from engine.data_loader import CONDITION_REGISTRY, ITEM_REGISTRY
-from engine.item import EquipItem, UtilitySpell
+from engine.item import EquipItem, UtilitySpell, Weapon
 from engine.strings import get_string
 from store import save_session_async
 
@@ -418,6 +418,7 @@ class EquipMenuView(discord.ui.View):
     """
     Top-level equipment menu — Equip / Unequip / Done buttons.
     This is what the player sees immediately after the character sheet is sent.
+    Dilettante characters with Weapon Forte also get a skill-specific button.
     """
 
     def __init__(self, char, state, channel_id: str):
@@ -425,6 +426,22 @@ class EquipMenuView(discord.ui.View):
         self.char = char
         self.state = state
         self.channel_id = channel_id
+
+        # Conditionally add Weapon Forte button for Dilettantes with the skill
+        skill_ids = {s.skill_id for s in CharacterManager.get_active_skills(char)}
+        if "dilettante_weapon_forte" in skill_ids:
+            btn = discord.ui.Button(
+                label=get_string("character.weapon_forte.button_label"),
+                style=discord.ButtonStyle.primary,
+            )
+            btn.callback = self._weapon_forte_btn
+            self.add_item(btn)
+
+    async def _weapon_forte_btn(self, interaction: discord.Interaction):
+        await interaction.response.edit_message(
+            content=get_string("character.weapon_forte.choose"),
+            view=FamiliarWeaponView(self.char, self.state, self.channel_id),
+        )
 
     @discord.ui.button(label="Equip Item", style=discord.ButtonStyle.primary)
     async def equip_btn(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -445,4 +462,94 @@ class EquipMenuView(discord.ui.View):
         await interaction.response.edit_message(
             content=_character_sheet(self.char, self.state),
             view=None,
+        )
+
+
+class FamiliarWeaponView(discord.ui.View):
+    """
+    Shown when a Dilettante taps "Weapon Forte".
+    Lists all weapons in inventory; selecting one sets it as the Forte weapon.
+    Also offers a Clear option if one is already selected.
+    """
+
+    def __init__(self, char, state, channel_id: str):
+        super().__init__(timeout=120)
+        self.char = char
+        self.state = state
+        self.channel_id = channel_id
+
+        options = []
+        has_familiar = any(i.familiar for i in char.inventory)
+
+        for inv in char.inventory:
+            if inv.container_id:
+                continue
+            defn = ITEM_REGISTRY.get(inv.item_id)
+            if defn is None or not isinstance(defn, Weapon):
+                continue
+            equipped_marker = " (equipped)" if inv.equipped else ""
+            familiar_marker = " ✓" if inv.familiar else ""
+            label = f"{defn.name}{familiar_marker}{equipped_marker}"
+            options.append(discord.SelectOption(
+                label=label[:100],
+                value=inv.instance_id,
+                description="Currently selected as Forte weapon" if inv.familiar else None,
+            ))
+
+        if has_familiar:
+            options.append(discord.SelectOption(
+                label="← Clear selection",
+                value="__clear",
+                description="Remove the current Forte weapon designation",
+            ))
+
+        if not options:
+            options = [discord.SelectOption(
+                label="(no weapons in inventory)",
+                value="__none",
+            )]
+
+        select = discord.ui.Select(
+            placeholder="Choose a weapon…",
+            options=options[:25],
+        )
+        select.callback = self._on_select
+        self.add_item(select)
+
+        back = discord.ui.Button(label="← Back", style=discord.ButtonStyle.secondary)
+        back.callback = self._on_back
+        self.add_item(back)
+
+    async def _on_select(self, interaction: discord.Interaction):
+        value = interaction.data["values"][0]
+
+        if value == "__none":
+            await interaction.response.edit_message(
+                content=get_string("character.weapon_forte.no_weapons"),
+                view=EquipMenuView(self.char, self.state, self.channel_id),
+            )
+            return
+
+        if value == "__clear":
+            result = set_familiar_weapon(self.state, self.char.character_id, None)
+            await save_session_async(self.state)
+            msg = result.message if result.ok else result.error
+            await interaction.response.edit_message(
+                content=msg,
+                view=EquipMenuView(self.char, self.state, self.channel_id),
+            )
+            return
+
+        result = set_familiar_weapon(self.state, self.char.character_id, value)
+        await save_session_async(self.state)
+        msg = result.message if result.ok else result.error
+        await interaction.response.edit_message(
+            content=msg,
+            view=EquipMenuView(self.char, self.state, self.channel_id),
+        )
+
+    async def _on_back(self, interaction: discord.Interaction):
+        await interaction.response.edit_message(
+            content=_character_sheet(self.char, self.state),
+            view=EquipMenuView(self.char, self.state, self.channel_id),
         )

--- a/data/actions/acquire.json
+++ b/data/actions/acquire.json
@@ -1,0 +1,11 @@
+{
+  "action_id": "acquire",
+  "label": "Acquire",
+  "button_style": "secondary",
+  "action_type": "affect",
+  "description": "FNS check (DC set by DM). Attempt to steal from a nearby enemy. Always requires DM resolution.",
+  "requires_target": "none",
+  "requires_destination": false,
+  "range_requirement": null,
+  "effect_tags": []
+}

--- a/data/actions/hide.json
+++ b/data/actions/hide.json
@@ -1,0 +1,16 @@
+{
+  "action_id": "hide",
+  "label": "Hide",
+  "button_style": "secondary",
+  "action_type": "combat",
+  "description": "Use oracle + move actions to enter hidden state. Cannot be targeted while hidden. First attack from hidden bypasses target DEF.",
+  "requires_target": "none",
+  "requires_destination": false,
+  "range_requirement": null,
+  "consumes_act": false,
+  "consumes_move": true,
+  "consumes_oracle": true,
+  "effect_tags": [
+    {"tag": "apply_condition", "condition": "hidden", "duration": null, "target": "self"}
+  ]
+}

--- a/data/actions/set_protector_target.json
+++ b/data/actions/set_protector_target.json
@@ -1,0 +1,22 @@
+{
+  "action_id": "set_protector_target",
+  "label": "Set Protector",
+  "button_style": "primary",
+  "action_type": "attack",
+  "description": "Apply your Protector bonus to an ally (oracle action, once per round). Switching targets replaces the existing protection.",
+  "requires_target": "allies",
+  "requires_destination": false,
+  "range_requirement": null,
+  "consumes_act": false,
+  "consumes_move": false,
+  "consumes_oracle": true,
+  "effect_tags": [
+    {
+      "tag": "apply_condition",
+      "condition": "protected",
+      "duration": null,
+      "repeal_existing": true,
+      "stacks_by_level": {"job": "KNIGHT", "tiers": [[1, 1], [3, 2], [5, 3]]}
+    }
+  ]
+}

--- a/data/actions/slip.json
+++ b/data/actions/slip.json
@@ -1,0 +1,22 @@
+{
+  "action_id": "slip",
+  "label": "Slip",
+  "button_style": "primary",
+  "action_type": "move",
+  "description": "FNS check (1d1000+FNS) vs DC 900. On success, gain immunity to opportunity attacks and move one range band.",
+  "requires_target": "none",
+  "requires_destination": true,
+  "consumes_act": false,
+  "consumes_move": true,
+  "effect_tags": [
+    {
+      "tag": "stat_check",
+      "stat": "finesse",
+      "dc": 900,
+      "on_success": [
+        {"tag": "apply_condition", "condition": "slipping", "duration": 1, "target": "self"},
+        "move_to_band"
+      ]
+    }
+  ]
+}

--- a/data/conditions/hidden.json
+++ b/data/conditions/hidden.json
@@ -1,0 +1,11 @@
+{
+  "condition_id": "hidden",
+  "label": "Hidden",
+  "duration_type": "permanent",
+  "stackable": false,
+  "hooks": {
+    "on_attack": {"tag": "remove_condition", "condition": "hidden"}
+  },
+  "stat_modifiers": {"bypass_defense": 1},
+  "grants_actions": []
+}

--- a/data/conditions/protected.json
+++ b/data/conditions/protected.json
@@ -1,0 +1,9 @@
+{
+  "condition_id": "protected",
+  "label": "Protected",
+  "duration_type": "permanent",
+  "stackable": true,
+  "hooks": {},
+  "stat_modifiers": {"defense": 100},
+  "grants_actions": []
+}

--- a/data/conditions/slipping.json
+++ b/data/conditions/slipping.json
@@ -1,0 +1,10 @@
+{
+  "condition_id": "slipping",
+  "label": "Slipping",
+  "duration_type": "rounds",
+  "stackable": false,
+  "hooks": {},
+  "stat_modifiers": {},
+  "grants_actions": [],
+  "tags": ["opportunity-attack-immune"]
+}

--- a/data/example_dungeon/the_gauntlet.json
+++ b/data/example_dungeon/the_gauntlet.json
@@ -29,7 +29,8 @@
             "door_state": "closed",
             "auto_move": true,
             "description": "The gateway consists of a round-topped arch and has a pair of stone doors with brass handles.",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           }
         ],
         "visited": false,
@@ -60,7 +61,8 @@
             "door_state": "open",
             "auto_move": true,
             "description": "The gateway leads back to the lower gates of the keep.",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           },
           {
             "exit_id": "0cdb55e3-bc86-4e97-bb49-b977ebbd9f3c",
@@ -70,7 +72,8 @@
             "door_state": "closed",
             "auto_move": false,
             "description": "Identical in appearance to the southern gateway, leads north.",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           },
           {
             "exit_id": "84a883c2-8ffa-4347-b2ec-4b96f8c4df6f",
@@ -80,7 +83,8 @@
             "door_state": "closed",
             "auto_move": false,
             "description": "Identical in appearance to the southern gateway, leads east.",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           }
         ],
         "visited": false,
@@ -118,7 +122,8 @@
             "door_state": "open",
             "auto_move": false,
             "description": "Eastern gateway leading back to The Gateway of Berghof",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           }
         ],
         "visited": false,
@@ -141,7 +146,8 @@
             "door_state": "open",
             "auto_move": false,
             "description": "Back to the Gateway of Berghof",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           },
           {
             "exit_id": "04ed425e-2e42-40f3-962d-695846da870b",
@@ -151,7 +157,8 @@
             "door_state": "closed",
             "auto_move": false,
             "description": "A partition of unclear substance and origin",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           }
         ],
         "visited": false,
@@ -196,7 +203,8 @@
             "door_state": "open",
             "auto_move": false,
             "description": "Uneven screen of unknown substance and origin",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           },
           {
             "exit_id": "864fd79e-a4de-4a54-ade4-a8255d15c681",
@@ -206,7 +214,8 @@
             "door_state": "closed",
             "auto_move": false,
             "description": "Uneven screen of unknown substance and origin",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           }
         ],
         "visited": false,
@@ -244,17 +253,19 @@
             "door_state": "open",
             "auto_move": false,
             "description": "Uneven screen of unknown material and origin",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           },
           {
             "exit_id": "efb3643c-76a4-4e4c-9395-15d6c7cc53f9",
             "label": "Wooden door (e)",
             "direction": null,
-            "destination_id": null,
+            "destination_id": "301fe2b0-d37f-4495-8fdf-1242823c9552",
             "door_state": "closed",
-            "auto_move": false,
+            "auto_move": true,
             "description": "Standard wooden door with iron handle",
-            "notes": ""
+            "notes": "",
+            "hidden": false
           }
         ],
         "visited": false,
@@ -265,34 +276,150 @@
       "301fe2b0-d37f-4495-8fdf-1242823c9552": {
         "room_id": "301fe2b0-d37f-4495-8fdf-1242823c9552",
         "name": "Painted room",
-        "description": "This octagonal room has a slender, stone pillar near the wall at each corner. The ceiling is painted to represent a domed roof, supported by these pillars, and the walls show a country scene which continues all the way around the room. With a little imagination, you could be standing in a summer house, surrounded by pleasant pastures and woodlands, at the top of a grassy slope leading down to a large lake.",
+        "description": "This octagonal room has a slender, stone pillar near the wall at each corner. The ceiling is painted to represent a domed roof, supported by these pillars, and the walls show a country scene which continues all the way around the room. With a little imagination, you could be standing near a summer house, surrounded by pleasant pastures and woodlands, at the top of a grassy slope leading down to a large lake.",
         "notes": "",
+        "features": [
+          {
+            "feature_id": "7b65eaba-3493-4dc1-87a2-af52442ff9e0",
+            "name": "Wall painting",
+            "description": "Depicts buildings on the SE wall. Paths leading into the horizon are depicted on the NE and NW walls.",
+            "state": "intact",
+            "notes": ""
+          },
+          {
+            "feature_id": "c9ae2836-360f-4ae1-be76-99667b91b156",
+            "name": "Pillars",
+            "description": "Four slender pillars stand at each corner of the room",
+            "state": "intact",
+            "notes": ""
+          }
+        ],
+        "exits": [
+          {
+            "exit_id": "a03f3700-5722-4f3f-b14d-77d2230d18f1",
+            "label": "Painted Door (NW)",
+            "direction": null,
+            "destination_id": "825c1784-525a-4a97-b2b3-df3225357161",
+            "door_state": "open",
+            "auto_move": false,
+            "description": "A door integrated into the painting as leading down a pathway to the horizon",
+            "notes": "",
+            "hidden": false
+          },
+          {
+            "exit_id": "74fa43d5-02f3-42f1-b2cf-ac08d8ab9e27",
+            "label": "Painted Door (SE)",
+            "direction": null,
+            "destination_id": "8723bd17-4b1c-4b5d-9a99-bac407ca5d24",
+            "door_state": "closed",
+            "auto_move": true,
+            "description": "A door integrated into the painting as a door to another house",
+            "notes": "",
+            "hidden": false
+          },
+          {
+            "exit_id": "36e72038-2ef4-457b-9847-c3d9a16dc1a3",
+            "label": "Painted door (NE)",
+            "direction": null,
+            "destination_id": "27da4ff9-dab0-415e-abef-6e0d7aff9b0b",
+            "door_state": "closed",
+            "auto_move": false,
+            "description": "A door integrated into the painting as leading down a pathway to the horizon",
+            "notes": "",
+            "hidden": true
+          }
+        ],
+        "visited": false,
+        "authored": true,
+        "exploration_xp": 0,
+        "random_encounter_modifier": 1.0
+      },
+      "8723bd17-4b1c-4b5d-9a99-bac407ca5d24": {
+        "room_id": "8723bd17-4b1c-4b5d-9a99-bac407ca5d24",
+        "name": "Release Chamber",
+        "description": "This room is circular and seems to be unoccupied. With the exception of a circular area in the center of the floor, the walls, floor and ceiling are of a smooth\npale grey stone. The circular area contains a stark spiral pattern in black and white",
+        "notes": "Room 9",
         "features": [],
-        "exits": [],
+        "exits": [
+          {
+            "exit_id": "cbaee0c5-1b6b-41c7-b0a2-9d94754896ae",
+            "label": "Stone Door (NW)",
+            "direction": null,
+            "destination_id": "301fe2b0-d37f-4495-8fdf-1242823c9552",
+            "door_state": "open",
+            "auto_move": true,
+            "description": "Ordinary door leading back to the painted room",
+            "notes": "",
+            "hidden": false
+          }
+        ],
+        "visited": false,
+        "authored": true,
+        "exploration_xp": 0,
+        "random_encounter_modifier": 0.0
+      },
+      "27da4ff9-dab0-415e-abef-6e0d7aff9b0b": {
+        "room_id": "27da4ff9-dab0-415e-abef-6e0d7aff9b0b",
+        "name": "Dormitory",
+        "description": "The air in this room is filled with the strong smell of sweat and the sound of none-too-gentle snoring. Much of the floor is covered with straw on which sprawl half a dozen humanoids wearing leather armor. One of them is clutching a flagon.",
+        "notes": "The sleeping gnolls each have 40d6gp. In addition one of them has a silver mirror (value-200gp) and another hasa rock crystal gem (value - 140gp). \nIf the adventurers take the opportunity to search the straw bedding, they will discover the following items: a small ivory ball (value - 300gp), a pair of silver tweezers (value - 10Ogp), and 73gp in coins.",
+        "features": [
+          {
+            "feature_id": "d840c727-6c6d-4300-9500-a70c1be19580",
+            "name": "Straw Bedding",
+            "description": "Straw spread across the floor serves as bedding for the gnolls",
+            "state": "filthy",
+            "notes": ""
+          }
+        ],
+        "exits": [
+          {
+            "exit_id": "096a0f82-8608-4cf1-9542-fc0c3cd9268e",
+            "label": "Stairway to Basement",
+            "direction": null,
+            "destination_id": "301fe2b0-d37f-4495-8fdf-1242823c9552",
+            "door_state": "open",
+            "auto_move": false,
+            "description": "Return to the Painted Room",
+            "notes": "",
+            "hidden": false
+          },
+          {
+            "exit_id": "ab801c6f-41a6-4739-b9b7-662f100d1903",
+            "label": "Wooden Door (W)",
+            "direction": null,
+            "destination_id": null,
+            "door_state": "closed",
+            "auto_move": false,
+            "description": "Ordinary wooden door",
+            "notes": "",
+            "hidden": false
+          }
+        ],
         "visited": false,
         "authored": true,
         "exploration_xp": 0,
         "random_encounter_modifier": 1.0
       }
     },
-    "entrance_id": null,
+    "entrance_id": "ba8d77a2-9b69-46cf-992a-5a4cd963e80a",
     "random_encounter_interval": 6,
     "random_encounter_roll": "1d6",
     "random_encounter_roster": []
   },
   "npc_roster": {
     "groups": {
-      "ceeb1615-1783-4b67-a6ed-29221ea629aa": {
-        "group_id": "ceeb1615-1783-4b67-a6ed-29221ea629aa",
-        "name": null,
+      "11d0394c-3f5c-4197-b765-182032732636": {
+        "group_id": "11d0394c-3f5c-4197-b765-182032732636",
+        "name": "Automatons",
         "npcs": [
           {
-            "npc_id": "156adc86-92e0-44ef-9c4d-e330f1b48650",
-            "name": "Automaton",
-            "description": "armored, wielding a mace",
-            "hp_max": 225,
-            "hp_current": 225,
-            "defense": 200,
+            "npc_id": "609a95e5-6af7-4389-a190-1ac54db0f728",
+            "name": "Chainmail Automaton",
+            "description": "Armed with a mace",
+            "hp_max": 600,
+            "hp_current": 600,
+            "defense": 150,
             "resistance": 0,
             "ability_scores": {
               "physique": 0,
@@ -309,14 +436,15 @@
             "weapon_range": 0,
             "status": "active",
             "notes": "",
-            "active_conditions": []
+            "active_conditions": [],
+            "hidden": true
           },
           {
-            "npc_id": "1860638d-fbf4-4558-8538-0c43c4f8b982",
-            "name": "Automaton",
-            "description": "",
-            "hp_max": 4,
-            "hp_current": 4,
+            "npc_id": "0d963341-316b-4df7-be3d-8ea4946d02cc",
+            "name": "Robed Automaton",
+            "description": "Armed with a staff",
+            "hp_max": 400,
+            "hp_current": 400,
             "defense": 0,
             "resistance": 0,
             "ability_scores": {
@@ -327,22 +455,23 @@
             },
             "movement_speed": 90,
             "attack_bonus": 0,
-            "damage_dice": "1d6",
+            "damage_dice": "6d130",
             "morale": 7,
             "saving_throw": 15,
-            "hit_dice": 1,
+            "hit_dice": 4,
             "weapon_range": 0,
             "status": "active",
             "notes": "",
-            "active_conditions": []
+            "active_conditions": [],
+            "hidden": true
           },
           {
-            "npc_id": "a65ba551-330a-4483-8cce-e3be8bddd846",
-            "name": "Automaton",
-            "description": "armored, wielding a mace",
-            "hp_max": 4,
-            "hp_current": 4,
-            "defense": 0,
+            "npc_id": "875e04ca-ace6-45ed-979f-56063b997cdb",
+            "name": "Plate Automaton",
+            "description": "Armed with a sword",
+            "hp_max": 800,
+            "hp_current": 800,
+            "defense": 200,
             "resistance": 0,
             "ability_scores": {
               "physique": 0,
@@ -352,19 +481,336 @@
             },
             "movement_speed": 90,
             "attack_bonus": 0,
-            "damage_dice": "1d6",
+            "damage_dice": "4d200",
             "morale": 7,
             "saving_throw": 15,
-            "hit_dice": 1,
+            "hit_dice": 8,
             "weapon_range": 0,
             "status": "active",
             "notes": "",
-            "active_conditions": []
+            "active_conditions": [],
+            "hidden": true
           }
         ],
         "possible_rooms": [],
         "movement_logic": "stationary",
-        "current_room_id": null,
+        "current_room_id": "b20a22a5-7ce4-4a29-8780-581e520036c1",
+        "patrol_route": []
+      },
+      "44a4cfd9-bd4b-46da-a9fd-3e3f61dc6ff6": {
+        "group_id": "44a4cfd9-bd4b-46da-a9fd-3e3f61dc6ff6",
+        "name": "Worker Ants",
+        "npcs": [
+          {
+            "npc_id": "0bd2e6a1-73c3-4391-9845-182cca3f83ee",
+            "name": "Worker Ant A",
+            "description": "",
+            "hp_max": 200,
+            "hp_current": 200,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "4d100",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "6be28d79-a5ea-46cd-8b9b-7d2bdb3096c0",
+            "name": "Worker Ant B",
+            "description": "",
+            "hp_max": 200,
+            "hp_current": 200,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "4d100",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "df7b85bb-2c9c-4145-a018-018a5d7be1c4",
+            "name": "Worker Ant C",
+            "description": "",
+            "hp_max": 200,
+            "hp_current": 200,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "4d100",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "4687055c-2f64-433c-9ba8-cc6430af34c3",
+            "name": "Worker Ant D",
+            "description": "",
+            "hp_max": 200,
+            "hp_current": 200,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "4d100",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 200,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          }
+        ],
+        "possible_rooms": [],
+        "movement_logic": "stationary",
+        "current_room_id": "caba1f5f-8876-446c-80c0-cfba1db259a2",
+        "patrol_route": []
+      },
+      "5f166fd9-c6d3-4639-9a91-376d116c6875": {
+        "group_id": "5f166fd9-c6d3-4639-9a91-376d116c6875",
+        "name": "Ant Queen and Guards",
+        "npcs": [
+          {
+            "npc_id": "f1860d84-3dc2-42c1-af85-e43c58afac87",
+            "name": "Giant Queen Ant",
+            "description": "",
+            "hp_max": 2000,
+            "hp_current": 2000,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "1",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 10,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "fb5a86bb-0407-4c00-8c7f-5570cc3f36a1",
+            "name": "Soldier Ant A",
+            "description": "",
+            "hp_max": 250,
+            "hp_current": 250,
+            "defense": 25,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "4d120",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 3,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "2a80306f-30e4-4be8-9771-d76b27015eee",
+            "name": "Soldier Ant B",
+            "description": "",
+            "hp_max": 250,
+            "hp_current": 250,
+            "defense": 25,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "4d120",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 3,
+            "weapon_range": 0,
+            "status": "active",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          }
+        ],
+        "possible_rooms": [],
+        "movement_logic": "stationary",
+        "current_room_id": "825c1784-525a-4a97-b2b3-df3225357161",
+        "patrol_route": []
+      },
+      "33c76083-8b53-4db4-b002-3a5b7f64ad1e": {
+        "group_id": "33c76083-8b53-4db4-b002-3a5b7f64ad1e",
+        "name": "Sleeping Gnolls",
+        "npcs": [
+          {
+            "npc_id": "b6ab63a0-3c82-4ec5-92a0-8a0450b432aa",
+            "name": "Gnoll A",
+            "description": "",
+            "hp_max": 400,
+            "hp_current": 400,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "2d400",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "asleep",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "09826714-e67f-4d18-8f55-c97b01831956",
+            "name": "Gnoll B",
+            "description": "",
+            "hp_max": 400,
+            "hp_current": 400,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "2d400",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "asleep",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "f0bd029f-27a3-4b89-8617-f528f72f2d41",
+            "name": "Gnoll C",
+            "description": "",
+            "hp_max": 400,
+            "hp_current": 400,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "2d400",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "asleep",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          },
+          {
+            "npc_id": "13a51a61-804e-4508-9b2c-2fe80f9d2a05",
+            "name": "Gnoll D",
+            "description": "",
+            "hp_max": 400,
+            "hp_current": 400,
+            "defense": 0,
+            "resistance": 0,
+            "ability_scores": {
+              "physique": 0,
+              "finesse": 0,
+              "reason": 0,
+              "savvy": 0
+            },
+            "movement_speed": 90,
+            "attack_bonus": 0,
+            "damage_dice": "2d400",
+            "morale": 7,
+            "saving_throw": 15,
+            "hit_dice": 2,
+            "weapon_range": 0,
+            "status": "asleep",
+            "notes": "",
+            "active_conditions": [],
+            "hidden": false
+          }
+        ],
+        "possible_rooms": [],
+        "movement_logic": "stationary",
+        "current_room_id": "27da4ff9-dab0-415e-abef-6e0d7aff9b0b",
         "patrol_route": []
       }
     }

--- a/data/jobskills/skills.json
+++ b/data/jobskills/skills.json
@@ -191,8 +191,10 @@
     "dilettante_knack": {
       "name": "Knack",
       "type": 9,
-      "desc": "You may either:\n - Make a SVY check in place of another check.\n - Use your SVY save in place of another save.\nGain an additional use at level 3, and again at level 5. Regain all uses at the start of a combat encounter.",
-      "uses": 1
+      "desc": "You may either:\n - Make a SVY check in place of another check.\n - Use your SVY save in place of another save.\nGain an additional use at level 3, and again at level 5. Regain all uses at the end of a combat encounter.",
+      "uses": 1,
+      "uses_scaling": [3, 5],
+      "recharge_period": "encounter"
     },
     "dilettante_weapon_forte": {
       "name": "Weapon Forte",

--- a/data/jobskills/skills.json
+++ b/data/jobskills/skills.json
@@ -150,7 +150,7 @@
       "type": 2,
       "desc": "DC: ? + [target FNS].\nMake a finesse check to steal an unequipped item from an enemy.",
       "dm_notes": "Base DCs are usually:\n500 - unequipped items\n700 - held items (level 3 or higher)\n900 - equipped items (level 5)\nSome items may be easier or harder to steal at your discretion",
-      "action_id": "affect"
+      "action_id": "acquire"
     },
     "thief_hide": {
       "name": "Hide",

--- a/data/jobskills/skills.json
+++ b/data/jobskills/skills.json
@@ -165,12 +165,9 @@
     },
     "thief_slip": {
       "name": "Slip",
-      "type": 4,
-      "desc": "On a successful FNS check, enemies cannot attack you for leaving the current zone until next turn.",
-      "check": {
-        "DC": 900,
-        "Stat": "FNS"
-      }
+      "type": 2,
+      "desc": "On a successful FNS check (DC 900), gain immunity to opportunity attacks and move one range band. Consumes your move action.",
+      "action_id": "slip"
     },
     "thief_disarmor": {
       "name": "Disarmor",

--- a/data/jobskills/skills.json
+++ b/data/jobskills/skills.json
@@ -126,8 +126,9 @@
     },
     "knight_protector": {
       "name": "Protector",
-      "type": 4,
-      "desc": "Give +1 DEF to one other party member or NPC. This bonus increases to +2 at level 3, and to +3 at level 5.\nYou may switch targets on your turn as part of an oracle action."
+      "type": 2,
+      "action_id": "set_protector_target",
+      "desc": "Give +100 DEF to one other party member. Bonus scales to +200 at L3 and +300 at L5. Oracle action — usable once per round."
     },
     "knight_rep": {
       "name": "Honorable Reputation",

--- a/data/jobskills/skills.json
+++ b/data/jobskills/skills.json
@@ -154,7 +154,8 @@
     },
     "thief_hide": {
       "name": "Hide",
-      "type": 3,
+      "type": 2,
+      "action_id": "hide",
       "desc": "*(you must use your oracle and move actions to use this in combat)*\nYou may hide on your turn. Opponents cannot target you while you are hidden. If you successfully attack while hidden, the damage bypasses your opponent's DEF, but you are no longer hidden."
     },
     "thief_disarm": {

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -175,6 +175,7 @@ combat:
     flee_success: "{actor_name} rolls {roll} + {finesse} = **{total}** vs {threshold}; the party flees!"
     flee_failure: "{actor_name} rolls {roll} + {finesse} = {total} vs {threshold}; failed to abscond."
     condition_expired: "{name}'s {cond_name} condition has expired."
+    condition_removed: "{name} is no longer {cond_name}."
     no_action: "The round passes without incident."
     stunned: "{actor_name} is stunned and cannot act this round!"
     action_out_of_range: "{actor_name} cannot use {label} from {band}, target is {dist} band(s) away (max {max_range})."

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -178,6 +178,7 @@ combat:
     no_action: "The round passes without incident."
     stunned: "{actor_name} is stunned and cannot act this round!"
     action_out_of_range: "{actor_name} cannot use {label} from {band}, target is {dist} band(s) away (max {max_range})."
+    oracle_already_used: "{actor_name} has already used their oracle action this round."
     moved_to: "Moved to **{destination}**."
   condition:
     applied: "{target_name} is now {label}."

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -205,6 +205,13 @@ character:
     no_items: "You have no equippable items."
     choose_item: "Choose an item from your inventory to equip:"
     choose_slot: "Choose a slot to unequip:"
+  weapon_forte:
+    button_label: "Weapon Forte"
+    choose: "Choose a weapon to designate as your Forte weapon (SVY replaces its normal stat):"
+    no_weapons: "You have no weapons in your inventory."
+    set: "{name} is now your Forte weapon."
+    already_set: "You have already selected {name} as your Forte weapon. Ask your DM to reset the selection."
+    cleared: "Weapon Forte selection cleared."
   errors:
     already_in_session: "**{name}** has already arrived."
     already_have_character: "You already have a character (**{name}**) in this session."

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -174,6 +174,8 @@ combat:
     flee_blocked: "{actor_name} tries to flee but {blocker} is blocking the way!"
     flee_success: "{actor_name} rolls {roll} + {finesse} = **{total}** vs {threshold}; the party flees!"
     flee_failure: "{actor_name} rolls {roll} + {finesse} = {total} vs {threshold}; failed to abscond."
+    stat_check_success: "{actor_name} rolls {roll} + {stat_value} = **{total}** vs DC {dc} — success!"
+    stat_check_failure: "{actor_name} rolls {roll} + {stat_value} = {total} vs DC {dc} — failed."
     condition_expired: "{name}'s {cond_name} condition has expired."
     condition_removed: "{name} is no longer {cond_name}."
     no_action: "The round passes without incident."

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -124,6 +124,18 @@ def unequip_item(state: GameState, character_id, slot):
     return cm.unequip_item(state, character_id, slot)
 
 
+def set_familiar_weapon(state: GameState, character_id, instance_id: str | None):
+    """
+    Set (or clear) the Weapon Forte familiar weapon for a Dilettante character.
+
+    instance_id=None clears the selection (DM reset).
+    Returns EngineResult with ok=False if the character lacks the skill or already
+    has a familiar weapon selected.
+    """
+    cm = CharacterManager()
+    return cm.set_familiar_weapon(state, character_id, instance_id)
+
+
 def remove_item(state: GameState, character_id, item_id: str, quantity: int = 1):
     """
     Remove item(s) from a character's inventory.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -199,6 +199,12 @@ def adjust_light_charges(state: GameState, character_id, item_id: str, delta: in
     return cm.adjust_light_charges(state, character_id, item_id, delta, equipped)
 
 
+def adjust_skill_uses(state: GameState, character_id, skill_id: str, delta: int):
+    """Adjust a skill's current uses by delta, clamped to [0, max_uses]."""
+    cm = CharacterManager()
+    return cm.adjust_skill_uses(state, character_id, skill_id, delta)
+
+
 def recharge_day_spells(state: GameState, character_id):
     """Restore all DAY-period spells to full charges for the given character."""
     cm = CharacterManager()
@@ -686,7 +692,7 @@ def render_status(state: GameState) -> str:
             lines.append("Features:")
             for feat in room.features:
                 state_note = f" [{feat.state}]" if feat.state and feat.state != "intact" else ""
-                lines.append(f"  {feat.name}{state_note}: {feat.description}")
+                lines.append(f" \u2023 {feat.name}{state_note}: {feat.description}")
         visible_exits = [e for e in room.exits if not e.hidden]
         if visible_exits:
             lines.append("Exits:")
@@ -828,5 +834,6 @@ __all__ = [
     "check_random_encounter",
     "adjust_spell_charges",
     "adjust_light_charges",
+    "adjust_skill_uses",
     "recharge_day_spells",
 ]

--- a/engine/character.py
+++ b/engine/character.py
@@ -794,6 +794,63 @@ class CharacterManager:
         state.updated_at = _now()
         return _ok(state, f"{char.name} unequipped {item_name} from the {slot.value} slot.")
 
+    def set_familiar_weapon(
+        self,
+        state: GameState,
+        character_id,
+        instance_id: str | None,
+        dm_reset: bool = False,
+    ):
+        """
+        Set or clear the Weapon Forte familiar weapon for a Dilettante character.
+
+        - instance_id=None clears all familiar flags (DM reset; skips skill check).
+        - Otherwise, validates the character has dilettante_weapon_forte, that no
+          weapon is already familiar (one-use restriction), and sets familiar=True
+          on the matching InventoryItem.
+        """
+        from engine import _now
+
+        char = state.characters.get(character_id)
+        if char is None:
+            return _err(state, f"Character {character_id} not found.")
+
+        if instance_id is None:
+            # DM reset: clear all familiar flags unconditionally
+            for item in char.inventory:
+                item.familiar = False
+            state.updated_at = _now()
+            return _ok(state, f"Weapon Forte selection cleared for {char.name}.")
+
+        # Skill gate
+        if not dm_reset:
+            skill_ids = {s.skill_id for s in self.get_active_skills(char)}
+            if "dilettante_weapon_forte" not in skill_ids:
+                return _err(state, f"{char.name} does not have the Weapon Forte skill.")
+
+        # One-use restriction
+        already_familiar = next((i for i in char.inventory if i.familiar), None)
+        if already_familiar is not None:
+            defn = ITEM_REGISTRY.get(already_familiar.item_id)
+            name = defn.name if defn else already_familiar.item_id
+            return _err(
+                state,
+                f"You have already selected {name} as your Forte weapon. "
+                "Ask your DM to reset the selection.",
+            )
+
+        inv_item = next((i for i in char.inventory if i.instance_id == instance_id), None)
+        if inv_item is None:
+            return _err(state, "Weapon not found in inventory.")
+
+        defn = ITEM_REGISTRY.get(inv_item.item_id)
+        if defn is None or not isinstance(defn, Weapon):
+            return _err(state, "Only weapons can be selected as a Forte weapon.")
+
+        inv_item.familiar = True
+        state.updated_at = _now()
+        return _ok(state, f"{defn.name} is now {char.name}'s Forte weapon.")
+
     # ------------------------------------------------------------------
     # XP and level-up
     # ------------------------------------------------------------------

--- a/engine/character.py
+++ b/engine/character.py
@@ -609,6 +609,49 @@ class CharacterManager:
         state.updated_at = _now()
         return _ok(state, f"{defn.name} charges: {inv_item.charges}/{defn.maxCharges}.")
 
+    @staticmethod
+    def get_skill_max_uses(skill_def, job_level: int) -> int:
+        """Compute max uses of a limited-use skill at the given job level."""
+        if skill_def.uses is None:
+            return 0
+        return skill_def.uses + sum(
+            1 for lvl in skill_def.uses_scaling if job_level >= lvl
+        )
+
+    def adjust_skill_uses(
+        self,
+        state: GameState,
+        character_id,
+        skill_id: str,
+        delta: int,
+    ):
+        """
+        Adjust a skill's current uses by delta (positive or negative).
+
+        Result is clamped to [0, max_uses]. Passing delta=9999 effectively
+        restores the skill to full uses.
+        """
+        from engine import _now
+
+        char = state.characters.get(character_id)
+        if char is None:
+            return _err(state, f"Character {character_id} not found.")
+
+        skill_def = next(
+            (s for s in self.get_active_skills(char) if s.skill_id == skill_id),
+            None,
+        )
+        if skill_def is None or skill_def.uses is None:
+            return _err(state, f"'{skill_id}' is not a limited-use skill for {char.name}.")
+
+        job_exp = char.jobs.get(skill_def.source)
+        job_level = job_exp.level if job_exp else char.level
+        max_uses = self.get_skill_max_uses(skill_def, job_level)
+        current = char.skill_uses.get(skill_id, max_uses)
+        char.skill_uses[skill_id] = max(0, min(max_uses, current + delta))
+        state.updated_at = _now()
+        return _ok(state, f"{skill_def.name} uses: {char.skill_uses[skill_id]}/{max_uses}.")
+
     def adjust_light_charges(
         self,
         state: GameState,
@@ -684,10 +727,20 @@ class CharacterManager:
             inv_item.charges = defn.maxCharges
             count += 1
 
+        # Also restore day-period skill uses.
+        skill_count = 0
+        for skill in self.get_active_skills(char):
+            if skill.uses is None or skill.recharge_period != "day":
+                continue
+            job_exp = char.jobs.get(skill.source)
+            job_level = job_exp.level if job_exp else char.level
+            char.skill_uses[skill.skill_id] = self.get_skill_max_uses(skill, job_level)
+            skill_count += 1
+
         state.updated_at = _now()
-        if count == 0:
-            return _ok(state, f"{char.name} has no daily spells to recharge.")
-        return _ok(state, f"Recharged {count} daily spell(s) for {char.name}.")
+        if count == 0 and skill_count == 0:
+            return _ok(state, f"{char.name} has no daily spells or skills to recharge.")
+        return _ok(state, f"Recharged {count} daily spell(s) and {skill_count} daily skill(s) for {char.name}.")
 
     def remove_item(
         self,

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -55,6 +55,7 @@ from .combat_hooks import (
     _effective_finesse,  # noqa: F401 — re-exported for tests
     _effective_stat_mod,  # noqa: F401 — re-exported for tests
     _find_npc,
+    _fire_on_attack_hooks,
     _fire_turn_start_hooks,
     _hook_apply_condition,  # noqa: F401 — re-exported for tests
     _hook_move_to_band,
@@ -429,6 +430,10 @@ def _execute_action(
     for hook_entry in action_def.effect_tags:
         _dispatch_hook(hook_entry, state, actor_id, action, log)
 
+    # Fire on_attack condition hooks after attack actions resolve
+    if action_def.action_type == "attack":
+        _fire_on_attack_hooks(state, actor_id, action, log)
+
     # Mark resource consumption flags after successful execution
     if cs is not None:
         if action_def.consumes_oracle:
@@ -441,6 +446,17 @@ def _execute_action(
 # _npc_decide
 # ---------------------------------------------------------------------------
 
+def _has_condition(state: GameState, cid: UUID, condition_id: str) -> bool:
+    """Return True if the combatant has an active instance of the given condition."""
+    char = state.characters.get(cid)
+    if char:
+        return any(c.condition_id == condition_id for c in char.active_conditions)
+    npc = _find_npc(state, cid)
+    if npc:
+        return any(c.condition_id == condition_id for c in npc.active_conditions)
+    return False
+
+
 def _npc_decide(
     state:  GameState,
     npc_id: UUID,
@@ -450,6 +466,7 @@ def _npc_decide(
     living_players = [
         (cid, pcs) for cid, pcs in state.battlefield.combatants.items()
         if pcs.is_player and _is_alive(state, cid)
+        and not _has_condition(state, cid, "hidden")
     ]
     if not living_players:
         return None

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -202,11 +202,13 @@ def apply_condition(
     condition_id: str,
     duration:     int | None = None,
     source_id:    UUID | None = None,
+    stacks:       int = 1,
 ) -> object:  # EngineResult
     """
     Apply a status condition to a combatant by ID.
     duration=None means permanent (removed only by explicit dispel).
     Re-applying an existing condition refreshes its duration.
+    stacks sets the initial stack count for stackable conditions.
     """
     if condition_id not in CONDITION_REGISTRY:
         return _err(state, f"Unknown condition '{condition_id}'.")
@@ -221,22 +223,35 @@ def apply_condition(
     target_name = _combatant_name(state, target_id)
 
     # Stackable conditions accumulate stacks rather than being replaced.
+    # Only increment the existing instance if the source matches (same source reapplying).
     if cond_def.stackable:
         existing = next(
-            (c for c in combatant.active_conditions if c.condition_id == condition_id), None
+            (c for c in combatant.active_conditions
+             if c.condition_id == condition_id and c.source_id == source_id),
+            None,
         )
         if existing is not None:
             existing.stacks += 1
             state.updated_at = _now()
             return _ok(state, fmt_string("combat.condition.stacked", target_name=target_name, label=cond_def.label, stacks=existing.stacks))
 
-    combatant.active_conditions = [
-        c for c in combatant.active_conditions if c.condition_id != condition_id
-    ]
+    if cond_def.stackable:
+        # For stackable conditions with multiple sources, preserve other sources' instances.
+        # Remove only this source's existing instance (if any) before re-adding.
+        combatant.active_conditions = [
+            c for c in combatant.active_conditions
+            if not (c.condition_id == condition_id and c.source_id == source_id)
+        ]
+    else:
+        # Non-stackable: replace any existing instance regardless of source.
+        combatant.active_conditions = [
+            c for c in combatant.active_conditions if c.condition_id != condition_id
+        ]
     combatant.active_conditions.append(ActiveCondition(
         condition_id=condition_id,
         duration_rounds=duration,
         source_id=source_id,
+        stacks=stacks,
     ))
     state.updated_at = _now()
     return _ok(state, fmt_string("combat.condition.applied", target_name=target_name, label=cond_def.label))
@@ -386,6 +401,15 @@ def _execute_action(
         log.append(f"[Unknown action '{action.action_id}' — skipped]")
         return
 
+    # Gate oracle-consuming actions
+    cs = state.battlefield.combatants.get(actor_id) if state.battlefield else None
+    if action_def.consumes_oracle and cs is not None and cs.used_oracle:
+        log.append(fmt_string(
+            "combat.log.oracle_already_used",
+            actor_name=_combatant_name(state, actor_id),
+        ))
+        return
+
     if isinstance(action_def.range_requirement, int):
         actor_cs  = state.battlefield.combatants.get(actor_id)
         target_cs = state.battlefield.combatants.get(action.target_id) if action.target_id else None
@@ -404,6 +428,13 @@ def _execute_action(
 
     for hook_entry in action_def.effect_tags:
         _dispatch_hook(hook_entry, state, actor_id, action, log)
+
+    # Mark resource consumption flags after successful execution
+    if cs is not None:
+        if action_def.consumes_oracle:
+            cs.used_oracle = True
+        if action_def.consumes_move:
+            cs.used_move = True
 
 
 # ---------------------------------------------------------------------------

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -133,7 +133,8 @@ class CombatAction:
 
     @property
     def is_affect(self) -> bool:
-        return self.action_id == "affect"
+        action_def = ACTION_REGISTRY.get(self.action_id)
+        return action_def is not None and action_def.action_type == "affect"
 
     def to_dict(self) -> dict:
         return {

--- a/engine/combat_hooks.py
+++ b/engine/combat_hooks.py
@@ -356,6 +356,16 @@ def _hook_weapon_attack(
         if targets_stat == "resistance"
         else _effective_defense(state, target_id)
     )
+    # If actor has bypass_defense (e.g. attacking from hidden), ignore mitigation
+    actor_combatant = state.characters.get(actor_id) or _find_npc(state, actor_id)
+    if actor_combatant:
+        bypass = sum(
+            CONDITION_REGISTRY[c.condition_id].stat_modifiers.get("bypass_defense", 0) * c.stacks
+            for c in actor_combatant.active_conditions
+            if c.condition_id in CONDITION_REGISTRY
+        )
+        if bypass > 0:
+            mitigation = 0
     damage = max(damage - mitigation, 0)
     if target_char:
         target_char.hp_current = max(0, target_char.hp_current - damage)
@@ -660,6 +670,34 @@ def _hook_apply_condition(
         log.append(fmt_string("combat.log.condition_applied", actor_name=actor_name, label=label, target_name=target_name, duration=duration))
 
 
+def _hook_remove_condition(
+    state:    GameState,
+    actor_id: UUID,
+    action,              # CombatAction | None
+    log:      list[str],
+    params:   dict,
+) -> None:
+    """
+    Remove all instances of a named condition from the actor.
+
+    params:
+      condition (str, required) — condition_id to remove
+    """
+    condition_id = params.get("condition")
+    if not condition_id:
+        log.append("[remove_condition: 'condition' param is required]")
+        return
+    combatant = state.characters.get(actor_id) or _find_npc(state, actor_id)
+    if combatant is None:
+        return
+    before = len(combatant.active_conditions)
+    combatant.active_conditions = [c for c in combatant.active_conditions if c.condition_id != condition_id]
+    if len(combatant.active_conditions) < before:
+        cond_def = CONDITION_REGISTRY.get(condition_id)
+        label = cond_def.label if cond_def else condition_id
+        log.append(fmt_string("combat.log.condition_removed", name=_combatant_name(state, actor_id), cond_name=label))
+
+
 def _hook_skip_action(
     state:    GameState,
     actor_id: UUID,
@@ -849,9 +887,10 @@ _HOOK_DISPATCH: dict[str, object] = {
     "move_to_band":    _hook_move_to_band,
     "block_movement":  _hook_block_movement,
     # Conditions
-    "apply_condition": _hook_apply_condition,
-    "deal_damage":     _hook_deal_damage,
-    "skip_action":     _hook_skip_action,
+    "apply_condition":  _hook_apply_condition,
+    "remove_condition": _hook_remove_condition,
+    "deal_damage":      _hook_deal_damage,
+    "skip_action":      _hook_skip_action,
     # Flee
     "abscond_roll":    _hook_abscond_roll,
     # Gear management
@@ -925,3 +964,16 @@ def _tick_conditions(state: GameState, log: list[str]) -> None:
         return
     for combatant_id in list(state.battlefield.combatants):
         _tick_actor_conditions(state, combatant_id, log)
+
+
+def _fire_on_attack_hooks(state: GameState, actor_id: UUID, action, log: list[str]) -> None:
+    """Fire on_attack hooks for the actor after they execute an attack action."""
+    char      = state.characters.get(actor_id)
+    npc       = _find_npc(state, actor_id)
+    combatant = char if char else npc
+    for cond in list(combatant.active_conditions if combatant else []):
+        cond_def = CONDITION_REGISTRY.get(cond.condition_id)
+        if cond_def:
+            entry = cond_def.hooks.get("on_attack")
+            if entry:
+                _dispatch_hook(entry, state, actor_id, action, log)

--- a/engine/combat_hooks.py
+++ b/engine/combat_hooks.py
@@ -810,6 +810,47 @@ def _hook_abscond_roll(
         log.append(fmt_string("combat.log.flee_failure", actor_name=actor_name, roll=roll, finesse=finesse, total=total, threshold=threshold))
 
 
+def _hook_stat_check(
+    state:    GameState,
+    actor_id: UUID,
+    action,              # CombatAction | None
+    log:      list[str],
+    params:   dict,
+) -> None:
+    """
+    General 1d1000 + stat vs DC check.
+    params:
+      stat:       AzureStats field name — "physique" | "finesse" | "reason" | "savvy"
+      dc:         int
+      on_success: list of hook entries dispatched on success (optional)
+      on_failure: list of hook entries dispatched on failure (optional)
+    """
+    stat_name  = params.get("stat", "finesse")
+    dc         = int(params.get("dc", 900))
+    actor_name = _combatant_name(state, actor_id)
+
+    roll       = random.randint(1, 1000)
+    stat_value = _effective_stat_mod(state, actor_id, stat_name)
+    total      = roll + stat_value
+
+    if total >= dc:
+        log.append(fmt_string(
+            "combat.log.stat_check_success",
+            actor_name=actor_name, stat=stat_name.upper()[:3],
+            roll=roll, stat_value=stat_value, total=total, dc=dc,
+        ))
+        for entry in params.get("on_success", []):
+            _dispatch_hook(entry, state, actor_id, action, log)
+    else:
+        log.append(fmt_string(
+            "combat.log.stat_check_failure",
+            actor_name=actor_name, stat=stat_name.upper()[:3],
+            roll=roll, stat_value=stat_value, total=total, dc=dc,
+        ))
+        for entry in params.get("on_failure", []):
+            _dispatch_hook(entry, state, actor_id, action, log)
+
+
 def _hook_resolve_equip(
     state:    GameState,
     actor_id: UUID,
@@ -893,6 +934,8 @@ _HOOK_DISPATCH: dict[str, object] = {
     "skip_action":      _hook_skip_action,
     # Flee
     "abscond_roll":    _hook_abscond_roll,
+    # General stat check
+    "stat_check":      _hook_stat_check,
     # Gear management
     "resolve_equip":   _hook_resolve_equip,
     "resolve_unequip": _hook_resolve_unequip,

--- a/engine/combat_hooks.py
+++ b/engine/combat_hooks.py
@@ -597,9 +597,13 @@ def _hook_apply_condition(
     Apply a condition to action.target_id, or to actor_id if params["target"] == "self".
 
     params:
-      condition  (str, required) — condition_id to apply
-      duration   (int, default 3) — duration in rounds; omit for permanent
-      target     (str, optional) — "self" to apply to the actor instead of action.target_id
+      condition       (str, required) — condition_id to apply
+      duration        (int | null, default 3) — duration in rounds; null for permanent
+      target          (str, optional) — "self" to apply to the actor instead of action.target_id
+      repeal_existing (bool, default False) — remove all prior instances of this condition
+                      placed by this actor (any target) before applying the new one
+      stacks_by_level (dict, optional) — compute initial stacks from actor's job level.
+                      Shape: {"job": "KNIGHT", "tiers": [[min_level, stacks], ...]}
     """
     condition_id = params.get("condition")
     if not condition_id:
@@ -622,9 +626,31 @@ def _hook_apply_condition(
         log.append(f"[apply_condition({condition_id}): target not on battlefield]")
         return
 
+    # Remove all prior instances of this condition applied by this actor
+    if params.get("repeal_existing"):
+        for char in state.active_characters:
+            char.active_conditions = [
+                c for c in char.active_conditions
+                if not (c.condition_id == condition_id and c.source_id == actor_id)
+            ]
+
+    # Compute stacks from actor job level if requested
+    stacks = 1
+    sbl = params.get("stacks_by_level")
+    if sbl:
+        actor_char = state.characters.get(actor_id)
+        if actor_char:
+            job_key = sbl["job"].lower()
+            job_exp = actor_char.jobs.get(job_key)
+            if job_exp:
+                for min_lv, s in reversed(sbl["tiers"]):
+                    if job_exp.level >= min_lv:
+                        stacks = s
+                        break
+
     duration = params.get("duration", 3)
     from engine.combat import apply_condition
-    apply_condition(state, target_id, condition_id, duration=duration, source_id=actor_id)
+    apply_condition(state, target_id, condition_id, duration=duration, source_id=actor_id, stacks=stacks)
 
     cond_def = CONDITION_REGISTRY.get(condition_id)
     label    = cond_def.label if cond_def else condition_id

--- a/engine/core.py
+++ b/engine/core.py
@@ -12,6 +12,7 @@ from models import (
     TurnStatus,
 )
 
+from .data_loader import ACTION_REGISTRY
 from .helpers import _err, _now, _ok, _snapshot
 from .light import _tick_light
 from .strings import fmt_string, get_string
@@ -117,7 +118,8 @@ class TurnManager:
             ]
             all_structured = all(
                 s.combat_action is not None and
-                s.combat_action.get("action_id") != "affect"
+                ACTION_REGISTRY.get(s.combat_action.get("action_id", ""), None) is not None and
+                ACTION_REGISTRY[s.combat_action["action_id"]].action_type != "affect"
                 for s in latest_subs
             )
             if all_structured:

--- a/engine/data_loader.py
+++ b/engine/data_loader.py
@@ -187,8 +187,10 @@ class SkillDef:
     stat:        str | None = None
     bonus:       int        = 0
     rank:        str | None = None
-    uses:        int | None = None
-    check:       dict | None = None
+    uses:           int | None  = None
+    uses_scaling:   list[int]   = field(default_factory=list)
+    recharge_period: str | None = None
+    check:          dict | None = None
 
 
 @dataclass
@@ -424,8 +426,15 @@ def _load_skill_definition(skill_id: str, sdata: dict, path: Path) -> SkillDef:
     """
     _validate_keys(sdata, _SKILL_DEF_REQUIRED, path)
 
-    skill_type = int(sdata["type"])
-    uses_raw   = sdata.get("uses")
+    skill_type       = int(sdata["type"])
+    uses_raw         = sdata.get("uses")
+    recharge_period  = sdata.get("recharge_period")
+    _VALID_RECHARGE  = {"encounter", "day"}
+    if recharge_period is not None and recharge_period not in _VALID_RECHARGE:
+        raise ValueError(
+            f"{path}: skill '{skill_id}' has invalid recharge_period '{recharge_period}'; "
+            f"must be one of {sorted(_VALID_RECHARGE)}"
+        )
 
     skill = SkillDef(
         skill_id=skill_id,
@@ -437,6 +446,8 @@ def _load_skill_definition(skill_id: str, sdata: dict, path: Path) -> SkillDef:
         dm_notes=sdata.get("dm_notes", ""),
         action_id=sdata.get("action_id"),
         uses=int(uses_raw) if uses_raw is not None else None,
+        uses_scaling=list(sdata.get("uses_scaling", [])),
+        recharge_period=recharge_period,
         check=sdata.get("check"),
     )
 

--- a/engine/data_loader.py
+++ b/engine/data_loader.py
@@ -108,6 +108,9 @@ class ActionDef:
     requires_destination: bool             = False
     range_requirement:    int | str | None = None
     effect_tags:          list[HookEntry]  = field(default_factory=list)
+    consumes_act:         bool             = True
+    consumes_move:        bool             = False
+    consumes_oracle:      bool             = False
 
 
 @dataclass
@@ -358,6 +361,9 @@ def _load_action(path: Path) -> ActionDef:
         requires_destination=bool(data["requires_destination"]),
         range_requirement=data.get("range_requirement"),
         effect_tags=raw_tags,
+        consumes_act=bool(data.get("consumes_act", True)),
+        consumes_move=bool(data.get("consumes_move", False)),
+        consumes_oracle=bool(data.get("consumes_oracle", False)),
     )
 
 

--- a/engine/session.py
+++ b/engine/session.py
@@ -122,6 +122,15 @@ class SessionManager:
                 if defn.maxCharges < 0:
                     continue
                 inv_item.charges = defn.maxCharges
+        # Restore encounter-period skill uses for all characters.
+        from engine.character import CharacterManager
+        for char in state.characters.values():
+            for skill in CharacterManager.get_active_skills(char):
+                if skill.uses is None or skill.recharge_period != "encounter":
+                    continue
+                job_exp = char.jobs.get(skill.source)
+                job_level = job_exp.level if job_exp else char.level
+                char.skill_uses[skill.skill_id] = CharacterManager.get_skill_max_uses(skill, job_level)
         state.updated_at = _now()
         return _ok(state, get_string("session.returning_to_exploration"))
 

--- a/engine/session.py
+++ b/engine/session.py
@@ -88,10 +88,13 @@ class SessionManager:
         state.rounds_started_at_turn = None
         state.battlefield = None
         # Expire any conditions scoped to rounds (duration_rounds is not None).
-        # Permanent conditions (duration_rounds=None) survive into exploration.
+        # Permanent conditions (duration_rounds=None) survive into exploration,
+        # except combat-only permanents like "protected" which are cleared here.
+        _COMBAT_ONLY_CONDITIONS = {"protected"}
         for char in state.characters.values():
             char.active_conditions = [
-                c for c in char.active_conditions if c.duration_rounds is None
+                c for c in char.active_conditions
+                if c.duration_rounds is None and c.condition_id not in _COMBAT_ONLY_CONDITIONS
             ]
         for group in state.npc_roster.groups.values():
             for npc in group.npcs:

--- a/models.py
+++ b/models.py
@@ -136,6 +136,7 @@ class InventoryItem:
     notes:        str    = ""
     container_id: str | None = None   # instance_id of owning ContainerItem, if any
     instance_id:  str    = field(default_factory=lambda: __import__("uuid").uuid4().hex)
+    familiar:     bool   = False       # Dilettante Weapon Forte: use SVY instead of normal stat
 
     @property
     def definition(self):
@@ -302,6 +303,13 @@ class Character:
                 agile_inv = _copy.copy(inv_item)
                 agile_inv.item_id = f"{inv_item.item_id}__agile"
                 results.append((agile_inv, agile_def))
+            if inv_item.familiar and getattr(definition, "stat", "physique") != "savvy":
+                familiar_def = _copy.copy(definition)
+                familiar_def.stat = "savvy"
+                familiar_def.name = f"{definition.name} [Forte]"
+                familiar_inv = _copy.copy(inv_item)
+                familiar_inv.item_id = f"{inv_item.item_id}__familiar"
+                results.append((familiar_inv, familiar_def))
             for tag in definition.getTags():
                 if tag.startswith("Throwable "):
                     try:

--- a/models.py
+++ b/models.py
@@ -184,6 +184,10 @@ class Character:
 
     active_conditions: list[ActiveCondition] = field(default_factory=list)
 
+    # Runtime tracking of limited-use skill uses. Keys are skill_id strings;
+    # values are remaining uses. Missing key means "at max uses" (backward compat).
+    skill_uses: dict[str, int] = field(default_factory=dict)
+
     # Metadata
     created_at:      datetime          = field(default_factory=lambda: datetime.now(UTC))
     is_pregenerated: bool              = False

--- a/persistence.py
+++ b/persistence.py
@@ -104,6 +104,9 @@ def _char_dict_from_row(row) -> dict:
         "active_conditions": json.loads(row["active_conditions_json"])
             if "active_conditions_json" in row.keys() and row["active_conditions_json"]  # noqa: SIM118
             else [],
+        "skill_uses": json.loads(row["skill_uses_json"])
+            if "skill_uses_json" in row.keys() and row["skill_uses_json"]  # noqa: SIM118
+            else {},
     }
     jobs_json = row["jobs_json"] if "jobs_json" in row else None # noqa: SIM401 (json, not dict)
     if jobs_json:
@@ -179,6 +182,10 @@ class Database:
         if "active_conditions_json" not in existing:
             self._conn.execute(
                 "ALTER TABLE characters ADD COLUMN active_conditions_json TEXT"
+            )
+        if "skill_uses_json" not in existing:
+            self._conn.execute(
+                "ALTER TABLE characters ADD COLUMN skill_uses_json TEXT"
             )
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS session_characters (
@@ -288,8 +295,8 @@ class Database:
                 movement_speed, saving_throws_json, status,
                 status_notes, inventory_json, gold,
                 created_at, is_pregenerated, updated_at, equipped_slots_json,
-                active_conditions_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                active_conditions_json, skill_uses_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(character_id) DO UPDATE SET
                 owner_id = excluded.owner_id,
                 name = excluded.name,
@@ -309,7 +316,8 @@ class Database:
                 is_pregenerated = excluded.is_pregenerated,
                 updated_at = excluded.updated_at,
                 equipped_slots_json = excluded.equipped_slots_json,
-                active_conditions_json = excluded.active_conditions_json
+                active_conditions_json = excluded.active_conditions_json,
+                skill_uses_json = excluded.skill_uses_json
             """,
             (
                 char_data["character_id"],
@@ -333,6 +341,7 @@ class Database:
                 _now_iso(),
                 json.dumps(char_data["equipped_slots"]),
                 json.dumps(char_data["active_conditions"]),
+                json.dumps(char_data["skill_uses"]),
             ),
         )
         self._conn.commit()

--- a/serialization.py
+++ b/serialization.py
@@ -73,6 +73,7 @@ def serialize_inventory_item(item: InventoryItem) -> dict:
         "notes":        item.notes,
         "container_id": item.container_id,
         "instance_id":  item.instance_id,
+        "familiar":     item.familiar,
     }
 
 
@@ -378,6 +379,7 @@ def deserialize_inventory_item(d: dict) -> InventoryItem:
         notes=d.get("notes", ""),
         container_id=d.get("container_id"),
         instance_id=d.get("instance_id") or _uuid.uuid4().hex,
+        familiar=d.get("familiar", False),
     )
 
 

--- a/serialization.py
+++ b/serialization.py
@@ -127,6 +127,7 @@ def serialize_character(c: Character) -> dict:
         "created_at":       _dt(c.created_at),
         "is_pregenerated":  c.is_pregenerated,
         "active_conditions": [serialize_active_condition(cond) for cond in c.active_conditions],
+        "skill_uses":        dict(c.skill_uses),
     }
 
 
@@ -432,6 +433,7 @@ def deserialize_character(d: dict) -> Character:
         created_at=_load_dt(d["created_at"]),
         is_pregenerated=d["is_pregenerated"],
         active_conditions=[deserialize_active_condition(c) for c in d.get("active_conditions", [])],
+        skill_uses=dict(d.get("skill_uses", {})),
     )
 
 

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -97,8 +97,14 @@ class TestCombatAction:
     def test_is_affect_true_for_affect(self):
         assert CombatAction(action_id="affect").is_affect is True
 
+    def test_is_affect_true_for_acquire(self):
+        assert CombatAction(action_id="acquire").is_affect is True
+
     def test_is_affect_false_for_attack(self):
         assert CombatAction(action_id="attack").is_affect is False
+
+    def test_is_affect_false_for_unknown_action(self):
+        assert CombatAction(action_id="unknown_xyz").is_affect is False
 
     def test_to_dict_and_from_dict_attack(self):
         tid = uuid4()
@@ -533,6 +539,27 @@ class TestAutoResolveTrigger:
         assert result.ok
         assert result.notify_dm is True            # DM must resolve
         assert state.current_turn is not None      # still open/closed for DM
+        assert state.current_turn.status == TurnStatus.CLOSED
+
+    def test_acquire_submission_suppresses_auto_resolve(self):
+        """Acquire (affect-type) among submissions → DM resolution required."""
+        state = _make_party_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        npc = state.npcs_in_current_room[0]
+        char_ids = list(state.characters.keys())
+
+        attack  = CombatAction(action_id="attack",  target_id=npc.npc_id)
+        acquire = CombatAction(action_id="acquire", free_text="I snatch the goblin's dagger.")
+
+        submit_turn(state, char_ids[0], "Attack",   combat_action=attack.to_dict())
+        result = submit_turn(state, char_ids[1], "Acquire", combat_action=acquire.to_dict())
+
+        assert result.ok
+        assert result.auto_resolved is False
+        assert result.notify_dm is True
+        assert state.current_turn is not None
         assert state.current_turn.status == TurnStatus.CLOSED
 
     def test_exploration_mode_never_auto_resolves(self):

--- a/tests/test_hide.py
+++ b/tests/test_hide.py
@@ -1,0 +1,296 @@
+"""
+tests/test_hide.py — Thief Hide skill tests.
+
+Covers:
+  - Hide action applies "hidden" condition to self
+  - Hidden character is not targeted by NPC AI
+  - Attacking while hidden bypasses target DEF and removes hidden
+  - Attacking without hidden uses normal DEF mitigation
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from engine import (
+    create_character,
+    enter_rounds,
+    start_session,
+)
+from engine.combat import CombatAction, _execute_action, _has_condition, _npc_decide
+from models import (
+    NPC,
+    ActiveCondition,
+    AzureStats,
+    CharacterClass,
+    GameState,
+    Party,
+    Room,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_state() -> GameState:
+    """Thief + Knight party, NPC in room, ready for combat."""
+    from engine import add_npc, register_room
+
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+    create_character(state, "Rynn",   CharacterClass.THIEF,  "Pack A", owner_id="u1")
+    create_character(state, "Aldric", CharacterClass.KNIGHT, "Pack A", owner_id="u2")
+    start_session(state)
+
+    room = Room(name="Hall", description="A stone hall.")
+    register_room(state, room)
+    state.current_room_id = room.room_id
+
+    # NPC with 0 finesse (always gets hit), high defense, high HP
+    npc = NPC(
+        name="Goblin",
+        hp_current=500,
+        hp_max=500,
+        defense=400,
+        ability_scores=AzureStats(finesse=0),
+        damage_dice="1d4",
+    )
+    add_npc(state, npc)
+    return state
+
+
+def _thief(state: GameState):
+    return next(c for c in state.active_characters if list(c.jobs.keys())[0].upper() == "THIEF")
+
+
+def _knight(state: GameState):
+    return next(c for c in state.active_characters if list(c.jobs.keys())[0].upper() == "KNIGHT")
+
+
+def _npc(state: GameState) -> NPC:
+    return state.npcs_in_current_room[0]
+
+
+# ---------------------------------------------------------------------------
+# Hide applies condition
+# ---------------------------------------------------------------------------
+
+class TestHideAppliesCondition:
+
+    def test_hide_action_applies_hidden_to_self(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        action = CombatAction(action_id="hide")
+        log: list[str] = []
+        _execute_action(state, thief.character_id, action, log)
+
+        assert any(c.condition_id == "hidden" for c in thief.active_conditions)
+
+    def test_hide_marks_oracle_and_move_used(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        cs = state.battlefield.combatants[thief.character_id]
+        action = CombatAction(action_id="hide")
+        _execute_action(state, thief.character_id, action, [])
+
+        assert cs.used_oracle is True
+        assert cs.used_move is True
+
+    def test_hide_oracle_gate_blocks_second_use(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        cs = state.battlefield.combatants[thief.character_id]
+        cs.used_oracle = True
+
+        _execute_action(state, thief.character_id, CombatAction(action_id="hide"), [])
+
+        assert not any(c.condition_id == "hidden" for c in thief.active_conditions)
+
+    def test_hide_does_not_consume_act(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        cs = state.battlefield.combatants[thief.character_id]
+        cs.acted_this_round = False
+
+        _execute_action(state, thief.character_id, CombatAction(action_id="hide"), [])
+
+        # acted_this_round is set by the round loop after _execute_action, not by the action itself
+        # — hide has consumes_act=False, so it shouldn't force the round to count it as the act
+        # We verify the condition applied (hide succeeded) but don't assert acted_this_round here
+        assert any(c.condition_id == "hidden" for c in thief.active_conditions)
+
+
+# ---------------------------------------------------------------------------
+# NPC ignores hidden players
+# ---------------------------------------------------------------------------
+
+class TestNPCIgnoresHidden:
+
+    def test_npc_does_not_target_hidden_player(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        knight = _knight(state)
+
+        # Hide the thief
+        thief.active_conditions.append(
+            ActiveCondition(condition_id="hidden", duration_rounds=None)
+        )
+
+        npc_obj = _npc(state)
+        npc_cs = state.battlefield.combatants[npc_obj.npc_id]
+        # Move NPC to ENGAGE range so it would attack if it had a valid target
+        from models import RangeBand
+        npc_cs.range_band = RangeBand.ENGAGE
+
+        decision = _npc_decide(state, npc_obj.npc_id, npc_cs)
+
+        # Should target the knight (not hidden), not the thief
+        if decision and decision.target_id:
+            assert decision.target_id == knight.character_id
+
+    def test_npc_has_no_target_when_only_player_is_hidden(self):
+        from engine import add_npc, register_room
+        state = GameState(platform_channel_id="ch2", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Rynn", CharacterClass.THIEF, "Pack A", owner_id="u1")
+        start_session(state)
+
+        room = Room(name="Cave", description="")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        npc = NPC(name="Rat", hp_current=10, hp_max=10, defense=0,
+                  ability_scores=AzureStats(finesse=0), damage_dice="1d2")
+        add_npc(state, npc)
+
+        enter_rounds(state)
+
+        thief = _thief(state)
+        thief.active_conditions.append(
+            ActiveCondition(condition_id="hidden", duration_rounds=None)
+        )
+
+        npc_cs = state.battlefield.combatants[npc.npc_id]
+        from models import RangeBand
+        npc_cs.range_band = RangeBand.ENGAGE
+
+        decision = _npc_decide(state, npc.npc_id, npc_cs)
+
+        # No valid targets — NPC should not attack
+        assert decision is None or decision.target_id is None
+
+    def test_has_condition_helper(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        assert not _has_condition(state, thief.character_id, "hidden")
+
+        thief.active_conditions.append(
+            ActiveCondition(condition_id="hidden", duration_rounds=None)
+        )
+        assert _has_condition(state, thief.character_id, "hidden")
+
+
+# ---------------------------------------------------------------------------
+# Attack from hidden bypasses DEF and removes hidden
+# ---------------------------------------------------------------------------
+
+class TestAttackFromHidden:
+
+    def _setup_hidden_thief_attack(self, state):
+        """Set up a hidden thief and NPC at ENGAGE range for a guaranteed hit."""
+        from models import RangeBand
+
+        thief = _thief(state)
+        npc_obj = _npc(state)
+
+        # Move both to ENGAGE range so the melee attack is in range
+        state.battlefield.combatants[thief.character_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc_obj.npc_id].range_band = RangeBand.ENGAGE
+
+        thief.active_conditions.append(
+            ActiveCondition(condition_id="hidden", duration_rounds=None)
+        )
+
+        action = CombatAction(action_id="attack", target_id=npc_obj.npc_id)
+        return thief, npc_obj, action
+
+    def test_attack_from_hidden_removes_hidden_condition(self):
+        state = _make_state()
+        enter_rounds(state)
+
+        thief, npc_obj, action = self._setup_hidden_thief_attack(state)
+
+        # side_effect order: attack roll, damage die (roll_dice_expr), crit roll
+        with patch("engine.combat_hooks.random.randint", side_effect=[1000, 1, 2]):
+            log: list[str] = []
+            _execute_action(state, thief.character_id, action, log)
+
+        assert not any(c.condition_id == "hidden" for c in thief.active_conditions), \
+            "Hidden condition should be removed after attacking"
+
+    def test_attack_from_hidden_bypasses_defense(self):
+        """With bypass_defense active, full damage is applied despite high DEF."""
+        state = _make_state()
+        enter_rounds(state)
+
+        thief, npc_obj, action = self._setup_hidden_thief_attack(state)
+        initial_hp = npc_obj.hp_current
+
+        # side_effect order: attack roll, damage die (roll_dice_expr), crit roll
+        with patch("engine.combat_hooks.random.randint", side_effect=[1000, 1, 2]):
+            _execute_action(state, thief.character_id, action, [])
+
+        assert npc_obj.hp_current < initial_hp, \
+            "NPC should take damage despite high DEF when attacker is hidden"
+
+    def test_attack_without_hidden_does_not_bypass_defense(self):
+        """Without hidden, high DEF reduces damage to 0."""
+        from models import RangeBand
+
+        state = _make_state()
+        enter_rounds(state)
+
+        thief = _thief(state)
+        npc_obj = _npc(state)
+        # Move to ENGAGE range; no hidden condition on thief
+        state.battlefield.combatants[thief.character_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc_obj.npc_id].range_band = RangeBand.ENGAGE
+        initial_hp = npc_obj.hp_current
+
+        action = CombatAction(action_id="attack", target_id=npc_obj.npc_id)
+        # side_effect order: attack roll, damage die (roll_dice_expr), crit roll
+        # 1d6 → 1 damage; NPC has 400 defense; 1 - 400 = 0 → no HP lost
+        with patch("engine.combat_hooks.random.randint", side_effect=[1000, 1, 2]):
+            _execute_action(state, thief.character_id, action, [])
+
+        assert npc_obj.hp_current == initial_hp, \
+            "NPC should take no damage when attacker is not hidden (high DEF blocks)"
+
+    def test_hidden_removed_in_log(self):
+        """Log should mention condition removal."""
+        state = _make_state()
+        enter_rounds(state)
+
+        thief, npc_obj, action = self._setup_hidden_thief_attack(state)
+        log: list[str] = []
+
+        with patch("engine.combat_hooks.random.randint", side_effect=[1000, 1, 2]):
+            _execute_action(state, thief.character_id, action, log)
+
+        assert any("Hidden" in entry or "hidden" in entry.lower() for entry in log), \
+            f"Log should mention hidden removal. Log was: {log}"

--- a/tests/test_protector.py
+++ b/tests/test_protector.py
@@ -26,7 +26,7 @@ from engine import (
     open_turn,
     start_session,
 )
-from engine.combat import CombatAction, _execute_action, apply_condition
+from engine.combat import CombatAction, _execute_action
 from models import (
     NPC,
     ActiveCondition,
@@ -35,9 +35,7 @@ from models import (
     Party,
     PlayerTurnSubmission,
     Room,
-    SessionMode,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_protector.py
+++ b/tests/test_protector.py
@@ -1,0 +1,379 @@
+"""
+tests/test_protector.py — Knight Protector skill tests.
+
+Covers:
+  - set_protector_target applies "protected" condition to ally
+  - DEF bonus scales with Knight level (stacks 1/2/3 → +100/200/300)
+  - repeal_existing removes old target's condition before applying new one
+  - Switching target marks used_oracle on the knight's CombatantState
+  - Oracle gate: action rejected when used_oracle is already True
+  - Initial set does not mark acted_this_round (consumes_act=False)
+  - exit_rounds clears "protected" conditions
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from engine import (
+    auto_resolve_round,
+    create_character,
+    enter_rounds,
+    exit_rounds,
+    open_turn,
+    start_session,
+)
+from engine.combat import CombatAction, _execute_action, apply_condition
+from models import (
+    NPC,
+    ActiveCondition,
+    CharacterClass,
+    GameState,
+    Party,
+    PlayerTurnSubmission,
+    Room,
+    SessionMode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_two_knight_state() -> GameState:
+    """Knight + Thief party, NPC in room, ready for combat."""
+    from engine import add_npc, register_room
+
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+    create_character(state, "Aldric", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+    create_character(state, "Rynn",   CharacterClass.THIEF,  "Pack A", owner_id="u2")
+    start_session(state)
+
+    room = Room(name="Hall", description="A stone hall.")
+    register_room(state, room)
+    state.current_room_id = room.room_id
+
+    add_npc(state, NPC(name="Goblin", hp_current=30, hp_max=30, defense=0, damage_dice="1d4"))
+    return state
+
+
+def _knight(state: GameState):
+    return next(c for c in state.active_characters if list(c.jobs.keys())[0].upper() == "KNIGHT")
+
+
+def _ally(state: GameState):
+    return next(c for c in state.active_characters if list(c.jobs.keys())[0].upper() != "KNIGHT")
+
+
+def _submit_protector(state: GameState, knight_id, target_id):
+    """Submit a set_protector_target action for knight targeting target."""
+    action = CombatAction(action_id="set_protector_target", target_id=target_id)
+    sub = PlayerTurnSubmission(
+        character_id=knight_id,
+        action_text="Set Protector",
+        is_latest=True,
+        combat_action=action.to_dict(),
+    )
+    state.current_turn.submissions = [sub]
+
+
+# ---------------------------------------------------------------------------
+# Basic application
+# ---------------------------------------------------------------------------
+
+class TestProtectorApply:
+
+    def test_protected_condition_applied_to_target(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond_ids = [c.condition_id for c in ally.active_conditions]
+        assert "protected" in cond_ids
+
+    def test_protected_condition_has_correct_source(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond = next(c for c in ally.active_conditions if c.condition_id == "protected")
+        assert cond.source_id == knight.character_id
+
+    def test_protected_is_permanent(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond = next(c for c in ally.active_conditions if c.condition_id == "protected")
+        assert cond.duration_rounds is None
+
+    def test_def_bonus_applied_via_defense_property(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        base_def = ally.defense
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        assert ally.defense == base_def + 100
+
+
+# ---------------------------------------------------------------------------
+# Level scaling
+# ---------------------------------------------------------------------------
+
+class TestProtectorLevelScaling:
+
+    def _set_knight_level(self, state, level):
+        knight = _knight(state)
+        knight.jobs["knight"].level = level
+
+    def test_level_1_gives_one_stack(self):
+        state = _make_two_knight_state()
+        self._set_knight_level(state, 1)
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond = next(c for c in ally.active_conditions if c.condition_id == "protected")
+        assert cond.stacks == 1
+        assert ally.defense == ally.defense - 100 + 100  # net +100
+
+    def test_level_3_gives_two_stacks(self):
+        state = _make_two_knight_state()
+        self._set_knight_level(state, 3)
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        base_def = ally.defense
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond = next(c for c in ally.active_conditions if c.condition_id == "protected")
+        assert cond.stacks == 2
+        assert ally.defense == base_def + 200
+
+    def test_level_5_gives_three_stacks(self):
+        state = _make_two_knight_state()
+        self._set_knight_level(state, 5)
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        base_def = ally.defense
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond = next(c for c in ally.active_conditions if c.condition_id == "protected")
+        assert cond.stacks == 3
+        assert ally.defense == base_def + 300
+
+    def test_level_4_gives_two_stacks(self):
+        """Level 4 is between L3 and L5 thresholds — should use L3 tier (2 stacks)."""
+        state = _make_two_knight_state()
+        self._set_knight_level(state, 4)
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        cond = next(c for c in ally.active_conditions if c.condition_id == "protected")
+        assert cond.stacks == 2
+
+
+# ---------------------------------------------------------------------------
+# Repeal existing / switching
+# ---------------------------------------------------------------------------
+
+class TestProtectorSwitch:
+
+    def _resolve_with_action(self, state, char_id, action):
+        state.current_turn.submissions = [PlayerTurnSubmission(
+            character_id=char_id,
+            action_text="action",
+            is_latest=True,
+            combat_action=action.to_dict(),
+        )]
+        auto_resolve_round(state)
+
+    def test_switch_removes_old_condition(self):
+        from engine import add_npc, register_room
+
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Aldric", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        create_character(state, "Rynn",   CharacterClass.THIEF,  "Pack A", owner_id="u2")
+        create_character(state, "Sera",   CharacterClass.MAGE,   "Pack A", owner_id="u3")
+        start_session(state)
+
+        room = Room(name="Hall", description="")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        add_npc(state, NPC(name="G", hp_current=30, hp_max=30, defense=0, damage_dice="1d4"))
+
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        chars = [c for c in state.active_characters if c.character_id != knight.character_id]
+        first_ally, second_ally = chars[0], chars[1]
+
+        # First protection
+        _submit_protector(state, knight.character_id, first_ally.character_id)
+        auto_resolve_round(state)
+        assert any(c.condition_id == "protected" for c in first_ally.active_conditions)
+
+        # Switch to second ally
+        open_turn(state)
+        # Reset oracle so the switch can proceed
+        cs = state.battlefield.combatants[knight.character_id]
+        cs.used_oracle = False
+        _submit_protector(state, knight.character_id, second_ally.character_id)
+        auto_resolve_round(state)
+
+        assert not any(c.condition_id == "protected" for c in first_ally.active_conditions), \
+            "Old target should lose Protected"
+        assert any(c.condition_id == "protected" for c in second_ally.active_conditions), \
+            "New target should gain Protected"
+
+    def test_action_marks_oracle_used_during_execution(self):
+        """_execute_action sets used_oracle=True for consumes_oracle actions."""
+        state = _make_two_knight_state()
+        enter_rounds(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+        cs = state.battlefield.combatants[knight.character_id]
+        assert cs.used_oracle is False
+
+        action = CombatAction(action_id="set_protector_target", target_id=ally.character_id)
+        log: list[str] = []
+        _execute_action(state, knight.character_id, action, log)
+
+        assert cs.used_oracle is True
+
+    def test_oracle_gate_blocks_second_use(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+
+        # Mark oracle already used
+        cs = state.battlefield.combatants[knight.character_id]
+        cs.used_oracle = True
+
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        # Condition should NOT have been applied
+        assert not any(c.condition_id == "protected" for c in ally.active_conditions)
+
+
+# ---------------------------------------------------------------------------
+# Repeal does not affect other sources
+# ---------------------------------------------------------------------------
+
+class TestProtectorRepeal:
+
+    def test_repeal_only_removes_own_source(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+
+        # Add a "protected" condition from a different source
+        other_id = ally.character_id  # treat ally as the fake other source
+        ally.active_conditions.append(ActiveCondition(
+            condition_id="protected",
+            duration_rounds=None,
+            source_id=other_id,
+            stacks=2,
+        ))
+
+        # Knight applies their own protection to ally
+        _submit_protector(state, knight.character_id, ally.character_id)
+        auto_resolve_round(state)
+
+        protected_conds = [c for c in ally.active_conditions if c.condition_id == "protected"]
+        # Should have two: one from other_id (untouched) + one from knight
+        assert len(protected_conds) == 2
+        sources = {c.source_id for c in protected_conds}
+        assert other_id in sources
+        assert knight.character_id in sources
+
+
+# ---------------------------------------------------------------------------
+# Exit rounds cleanup
+# ---------------------------------------------------------------------------
+
+class TestProtectorCleanup:
+
+    def test_protected_removed_on_exit_rounds(self):
+        state = _make_two_knight_state()
+        enter_rounds(state)
+        open_turn(state)
+
+        knight = _knight(state)
+        ally   = _ally(state)
+
+        ally.active_conditions.append(ActiveCondition(
+            condition_id="protected",
+            duration_rounds=None,
+            source_id=knight.character_id,
+            stacks=1,
+        ))
+
+        exit_rounds(state)
+
+        assert not any(c.condition_id == "protected" for c in ally.active_conditions)
+
+    def test_permanent_non_combat_condition_survives_exit(self):
+        """Permanent conditions that are not combat-only still survive exit_rounds."""
+        state = _make_two_knight_state()
+        enter_rounds(state)
+
+        ally = _ally(state)
+        ally.active_conditions.append(ActiveCondition(
+            condition_id="strengthened",
+            duration_rounds=None,
+        ))
+
+        exit_rounds(state)
+
+        assert any(c.condition_id == "strengthened" for c in ally.active_conditions)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -9,9 +9,20 @@ Covers:
   - Action buttons include COMBAT_ACTION skills
 """
 
+import os
+import tempfile
+
 import pytest
 
-from engine import create_character, equip_item, give_item
+from engine import (
+    adjust_skill_uses,
+    create_character,
+    enter_rounds,
+    equip_item,
+    exit_rounds,
+    give_item,
+    recharge_day_spells,
+)
 from engine.azure_constants import XP_THRESHOLDS, SkillType
 from engine.character import CharacterManager
 from engine.data_loader import CLASS_DEFINITIONS, ITEM_REGISTRY, SkillDef
@@ -239,3 +250,129 @@ class TestSkillRegistry:
                     assert skill.action_id is not None, (
                         f"Job {key} COMBAT_ACTION skill '{skill.name}' has no action_id"
                     )
+
+
+# ---------------------------------------------------------------------------
+# Skill uses tracking (Knack / limited-use skills)
+# ---------------------------------------------------------------------------
+
+def _make_dilettante(state, name="Dill"):
+    result = create_character(state, name, CharacterClass.DILETTANTE, "", owner_id="u_dill")
+    assert result.ok
+    return next(iter(state.characters.values()))
+
+
+def _knack_def():
+    """Return the SkillDef for dilettante_knack."""
+    job_def = CLASS_DEFINITIONS.get("DILETTANTE")
+    assert job_def is not None
+    skill = job_def.skills.get("dilettante_knack")
+    assert skill is not None
+    return skill
+
+
+class TestSkillUses:
+
+    def test_knack_skill_def_fields(self):
+        skill = _knack_def()
+        assert skill.uses == 1
+        assert skill.uses_scaling == [3, 5]
+        assert skill.recharge_period == "encounter"
+
+    def test_get_skill_max_uses_at_level_1(self):
+        skill = _knack_def()
+        assert CharacterManager.get_skill_max_uses(skill, 1) == 1
+
+    def test_get_skill_max_uses_at_level_2(self):
+        skill = _knack_def()
+        assert CharacterManager.get_skill_max_uses(skill, 2) == 1
+
+    def test_get_skill_max_uses_at_level_3(self):
+        skill = _knack_def()
+        assert CharacterManager.get_skill_max_uses(skill, 3) == 2
+
+    def test_get_skill_max_uses_at_level_4(self):
+        skill = _knack_def()
+        assert CharacterManager.get_skill_max_uses(skill, 4) == 2
+
+    def test_get_skill_max_uses_at_level_5(self):
+        skill = _knack_def()
+        assert CharacterManager.get_skill_max_uses(skill, 5) == 3
+
+    def test_adjust_skill_uses_decrements(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        result = adjust_skill_uses(state, char.character_id, "dilettante_knack", -1)
+        assert result.ok
+        assert char.skill_uses["dilettante_knack"] == 0
+
+    def test_adjust_skill_uses_clamps_at_zero(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        result = adjust_skill_uses(state, char.character_id, "dilettante_knack", -9999)
+        assert result.ok
+        assert char.skill_uses["dilettante_knack"] == 0
+
+    def test_adjust_skill_uses_clamps_at_max(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        # Start at 0, try to go over max
+        char.skill_uses["dilettante_knack"] = 0
+        result = adjust_skill_uses(state, char.character_id, "dilettante_knack", 9999)
+        assert result.ok
+        assert char.skill_uses["dilettante_knack"] == 1  # max at L1
+
+    def test_adjust_skill_uses_error_on_non_limited_skill(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        result = adjust_skill_uses(state, char.character_id, "dilettante_weapon_forte", -1)
+        assert not result.ok
+
+    def test_exit_rounds_restores_encounter_skill_uses(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        # Drain to 0
+        char.skill_uses["dilettante_knack"] = 0
+        enter_rounds(state)
+        exit_rounds(state)
+        assert char.skill_uses["dilettante_knack"] == 1  # restored to max at L1
+
+    def test_recharge_day_does_not_restore_encounter_skills(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        char.skill_uses["dilettante_knack"] = 0
+        recharge_day_spells(state, char.character_id)
+        # encounter-period skill should still be at 0
+        assert char.skill_uses.get("dilettante_knack", 1) == 0
+
+    def test_skill_uses_survive_persistence_round_trip(self):
+        from persistence import Database
+        state = _make_state()
+        char = _make_dilettante(state)
+        char.skill_uses["dilettante_knack"] = 0
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            db = Database(db_path)
+            db.save(state)
+            loaded = db.load("ch_skills_test")
+            db.close()
+        finally:
+            os.unlink(db_path)
+
+        assert loaded is not None
+        loaded_char = next(iter(loaded.characters.values()))
+        assert loaded_char.skill_uses.get("dilettante_knack") == 0
+
+    def test_missing_skill_uses_defaults_to_max(self):
+        state = _make_state()
+        char = _make_dilettante(state)
+        # skill_uses empty → should read as at max
+        char.skill_uses.clear()
+        skill = _knack_def()
+        job_exp = char.jobs.get(skill.source)
+        job_level = job_exp.level if job_exp else char.level
+        max_uses = CharacterManager.get_skill_max_uses(skill, job_level)
+        current = char.skill_uses.get("dilettante_knack", max_uses)
+        assert current == max_uses

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -376,3 +376,66 @@ class TestSkillUses:
         max_uses = CharacterManager.get_skill_max_uses(skill, job_level)
         current = char.skill_uses.get("dilettante_knack", max_uses)
         assert current == max_uses
+
+
+# ---------------------------------------------------------------------------
+# Thief skill level gates (Acquire / Disarm / Disarmor)
+# ---------------------------------------------------------------------------
+
+class TestThiefSkillLevelGates:
+
+    def _make_thief(self, state):
+        result = create_character(state, "Rogue", CharacterClass.THIEF, "", owner_id="user_001")
+        assert result.ok
+        return next(iter(state.characters.values()))
+
+    def test_thief_level_1_has_acquire(self):
+        state = _make_state()
+        char = self._make_thief(state)
+        skills = CharacterManager.get_active_skills(char)
+        skill_ids = [s.skill_id for s in skills]
+        assert "thief_acquire" in skill_ids
+        acquire = next(s for s in skills if s.skill_id == "thief_acquire")
+        assert acquire.action_id == "acquire"
+
+    def test_thief_level_1_does_not_have_disarm(self):
+        state = _make_state()
+        char = self._make_thief(state)
+        skills = CharacterManager.get_active_skills(char)
+        assert not any(s.skill_id == "thief_disarm" for s in skills)
+
+    def test_thief_level_3_has_disarm(self):
+        state = _make_state()
+        char = self._make_thief(state)
+        _level_up_to(state, char.character_id, 3)
+        skills = CharacterManager.get_active_skills(char)
+        skill_ids = [s.skill_id for s in skills]
+        assert "thief_disarm" in skill_ids
+        disarm = next(s for s in skills if s.skill_id == "thief_disarm")
+        assert disarm.skill_type == SkillType.SIMPLE.value
+        assert disarm.action_id is None
+
+    def test_thief_level_2_does_not_have_disarm(self):
+        state = _make_state()
+        char = self._make_thief(state)
+        _level_up_to(state, char.character_id, 2)
+        skills = CharacterManager.get_active_skills(char)
+        assert not any(s.skill_id == "thief_disarm" for s in skills)
+
+    def test_thief_level_5_has_disarmor(self):
+        state = _make_state()
+        char = self._make_thief(state)
+        _level_up_to(state, char.character_id, 5)
+        skills = CharacterManager.get_active_skills(char)
+        skill_ids = [s.skill_id for s in skills]
+        assert "thief_disarmor" in skill_ids
+        disarmor = next(s for s in skills if s.skill_id == "thief_disarmor")
+        assert disarmor.skill_type == SkillType.SIMPLE.value
+        assert disarmor.action_id is None
+
+    def test_thief_level_4_does_not_have_disarmor(self):
+        state = _make_state()
+        char = self._make_thief(state)
+        _level_up_to(state, char.character_id, 4)
+        skills = CharacterManager.get_active_skills(char)
+        assert not any(s.skill_id == "thief_disarmor" for s in skills)

--- a/tests/test_slip.py
+++ b/tests/test_slip.py
@@ -1,0 +1,246 @@
+"""
+tests/test_slip.py — Thief Slip skill tests.
+
+Covers:
+  - Successful FNS check applies slipping condition and moves thief
+  - Failed FNS check: no condition, no movement
+  - Slip consumes the move action, not the ACT action
+  - Slipping condition suppresses opportunity attacks
+  - Level gate: Slip only available at thief level >= 3
+  - slipping condition survives a persistence round-trip
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from engine import (
+    create_character,
+    enter_rounds,
+    start_session,
+)
+from engine.combat import CombatAction, _execute_action
+from models import (
+    NPC,
+    AzureStats,
+    CharacterClass,
+    GameState,
+    Party,
+    RangeBand,
+    Room,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_state() -> tuple[GameState, object, object]:
+    """Thief + NPC at ENGAGE, thief has 0 finesse for deterministic roll math."""
+    from engine import add_npc, register_room
+
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+    create_character(state, "Rynn", CharacterClass.THIEF, "Pack A", owner_id="u1")
+    start_session(state)
+
+    room = Room(name="Hall", description="A stone hall.")
+    register_room(state, room)
+    state.current_room_id = room.room_id
+
+    npc = NPC(
+        name="Goblin",
+        hp_current=200,
+        hp_max=200,
+        defense=0,
+        ability_scores=AzureStats(finesse=0),
+        damage_dice="1d6",
+    )
+    add_npc(state, npc)
+    enter_rounds(state)
+
+    thief = next(c for c in state.active_characters
+                 if list(c.jobs.keys())[0].upper() == "THIEF")
+    # Fix finesse to 0 so roll alone determines check outcome
+    thief.ability_scores = AzureStats(finesse=0)
+
+    # Place both at ENGAGE so opportunity attacks would fire on movement
+    state.battlefield.combatants[thief.character_id].range_band = RangeBand.ENGAGE
+    state.battlefield.combatants[npc.npc_id].range_band = RangeBand.ENGAGE
+
+    return state, thief, npc
+
+
+def _thief(state: GameState):
+    return next(c for c in state.active_characters
+                if list(c.jobs.keys())[0].upper() == "THIEF")
+
+
+# ---------------------------------------------------------------------------
+# FNS check success
+# ---------------------------------------------------------------------------
+
+class TestSlipSuccess:
+
+    def test_success_applies_slipping_condition(self):
+        state, thief, _ = _make_state()
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+        # roll=900 + finesse=0 = 900 >= 900 → success
+        with patch("engine.combat_hooks.random.randint", return_value=900):
+            _execute_action(state, thief.character_id, action, [])
+
+        assert any(c.condition_id == "slipping" for c in thief.active_conditions)
+
+    def test_success_moves_thief(self):
+        state, thief, _ = _make_state()
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+        with patch("engine.combat_hooks.random.randint", return_value=900):
+            _execute_action(state, thief.character_id, action, [])
+
+        cs = state.battlefield.combatants[thief.character_id]
+        assert cs.range_band == RangeBand.CLOSE_MINUS
+
+    def test_success_suppresses_opportunity_attacks(self):
+        """NPC does not fire an opportunity attack when thief has slipping condition."""
+        state, thief, npc = _make_state()
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+
+        log: list[str] = []
+        # roll=900 → stat check succeeds; randint also used in attack roll if opp fires
+        with patch("engine.combat_hooks.random.randint", return_value=900):
+            _execute_action(state, thief.character_id, action, log)
+
+        assert not any("opportunity attack" in line.lower() for line in log)
+
+
+# ---------------------------------------------------------------------------
+# FNS check failure
+# ---------------------------------------------------------------------------
+
+class TestSlipFailure:
+
+    def test_failure_does_not_apply_condition(self):
+        state, thief, _ = _make_state()
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+        # roll=1 + finesse=0 = 1 < 900 → failure
+        with patch("engine.combat_hooks.random.randint", return_value=1):
+            _execute_action(state, thief.character_id, action, [])
+
+        assert not any(c.condition_id == "slipping" for c in thief.active_conditions)
+
+    def test_failure_does_not_move_thief(self):
+        state, thief, _ = _make_state()
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+        with patch("engine.combat_hooks.random.randint", return_value=1):
+            _execute_action(state, thief.character_id, action, [])
+
+        cs = state.battlefield.combatants[thief.character_id]
+        assert cs.range_band == RangeBand.ENGAGE
+
+
+# ---------------------------------------------------------------------------
+# Action resource consumption
+# ---------------------------------------------------------------------------
+
+class TestSlipResourceConsumption:
+
+    def test_slip_consumes_move_not_act(self):
+        state, thief, _ = _make_state()
+        cs = state.battlefield.combatants[thief.character_id]
+        cs.acted_this_round = False
+
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+        with patch("engine.combat_hooks.random.randint", return_value=900):
+            _execute_action(state, thief.character_id, action, [])
+
+        assert cs.used_move is True
+        assert cs.acted_this_round is False
+
+    def test_slip_failure_still_consumes_move(self):
+        state, thief, _ = _make_state()
+        cs = state.battlefield.combatants[thief.character_id]
+
+        action = CombatAction(action_id="slip", destination=RangeBand.CLOSE_MINUS)
+        with patch("engine.combat_hooks.random.randint", return_value=1):
+            _execute_action(state, thief.character_id, action, [])
+
+        assert cs.used_move is True
+
+
+# ---------------------------------------------------------------------------
+# Level gate
+# ---------------------------------------------------------------------------
+
+class TestSlipLevelGate:
+
+    def test_slip_unavailable_below_level_3(self):
+        from engine.character import CharacterManager
+        state = GameState(platform_channel_id="ch2", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Rynn", CharacterClass.THIEF, "Pack A", owner_id="u1")
+        start_session(state)
+        thief = next(c for c in state.active_characters
+                     if list(c.jobs.keys())[0].upper() == "THIEF")
+
+        # Default level is 1; thief_slip requires level 3
+        thief_job_key = list(thief.jobs.keys())[0]
+        thief.jobs[thief_job_key].level = 2
+        active_skills = CharacterManager.get_active_skills(thief)
+        action_ids = {s.action_id for s in active_skills if s.action_id}
+        assert "slip" not in action_ids
+
+    def test_slip_available_at_level_3(self):
+        from engine.character import CharacterManager
+        state = GameState(platform_channel_id="ch3", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Rynn", CharacterClass.THIEF, "Pack A", owner_id="u1")
+        start_session(state)
+        thief = next(c for c in state.active_characters
+                     if list(c.jobs.keys())[0].upper() == "THIEF")
+
+        thief_job_key = list(thief.jobs.keys())[0]
+        thief.jobs[thief_job_key].level = 3
+        active_skills = CharacterManager.get_active_skills(thief)
+        action_ids = {s.action_id for s in active_skills if s.action_id}
+        assert "slip" in action_ids
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip
+# ---------------------------------------------------------------------------
+
+class TestSlipPersistence:
+
+    def test_slipping_condition_survives_round_trip(self, tmp_path):
+        import tempfile
+
+        from engine import apply_condition
+        from persistence import Database
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        db = Database(db_path)
+        try:
+            state = GameState(platform_channel_id="ch4", dm_user_id="dm")
+            state.party = Party(name="P")
+            create_character(state, "Rynn", CharacterClass.THIEF, "Pack A", owner_id="u1")
+            start_session(state)
+            char = next(c for c in state.active_characters
+                        if list(c.jobs.keys())[0].upper() == "THIEF")
+
+            apply_condition(state, char.character_id, "slipping", duration=1)
+            assert any(c.condition_id == "slipping" for c in char.active_conditions)
+
+            db.save_character(char)
+            reloaded = db.load_character(str(char.character_id))
+
+            assert any(c.condition_id == "slipping" for c in reloaded.active_conditions)
+            assert reloaded.active_conditions[0].duration_rounds == 1
+        finally:
+            db.close()
+            import os
+            os.unlink(db_path)

--- a/tests/test_weapon_forte.py
+++ b/tests/test_weapon_forte.py
@@ -1,0 +1,302 @@
+"""
+tests/test_weapon_forte.py — Dilettante Weapon Forte skill.
+
+Covers:
+  - equipped_weapons() returns a [Forte] SVY variant when familiar=True
+  - [Forte] variant absent when item is not equipped
+  - Registry definition not mutated by variant generation
+  - set_familiar_weapon: sets the flag, enforces one-use, resets, skill gate
+  - Integration: _hook_weapon_attack resolves the familiar weapon_id using SVY
+  - Serialization round-trip: familiar flag survives serialize/deserialize
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from engine import create_character, start_session
+from models import CharacterClass, GameState, InventoryItem, Party
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WEAPON_ID = "shortsword"   # rank D, stat physique — equippable by Dilettante
+
+
+def _make_state_with_dilettante():
+    """EXPLORATION state with one Dilettante (has dilettante_weapon_forte at L1)."""
+    from engine import register_room
+    from models import Room
+
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+    create_character(state, "Rhiannon", CharacterClass.DILETTANTE, "", owner_id="u1")
+    start_session(state)
+    room = Room(name="Hall", description="Stone hall.")
+    register_room(state, room)
+    state.current_room_id = room.room_id
+    char = next(iter(state.characters.values()))
+    return state, char
+
+
+def _make_state_with_knight():
+    """EXPLORATION state with one Knight (no weapon forte skill)."""
+    from engine import register_room
+    from models import Room
+
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+    create_character(state, "Aldric", CharacterClass.KNIGHT, "", owner_id="u1")
+    start_session(state)
+    room = Room(name="Hall", description="Stone hall.")
+    register_room(state, room)
+    state.current_room_id = room.room_id
+    char = next(iter(state.characters.values()))
+    return state, char
+
+
+def _add_equipped(char, item_id, familiar=False):
+    """Add item to inventory as equipped in main_hand (bypasses rank enforcement)."""
+    from engine.azure_constants import ItemSlot
+    inv = InventoryItem(item_id=item_id, equipped=True, familiar=familiar)
+    char.inventory.append(inv)
+    char.equipped_slots[ItemSlot.MAIN_HAND.value] = item_id
+    return inv
+
+
+def _add_unequipped(char, item_id, familiar=False):
+    """Add item to inventory, not equipped."""
+    inv = InventoryItem(item_id=item_id, familiar=familiar)
+    char.inventory.append(inv)
+    return inv
+
+
+# ---------------------------------------------------------------------------
+# equipped_weapons() — Forte variant
+# ---------------------------------------------------------------------------
+
+class TestForteEquippedWeapons:
+    def test_familiar_flag_creates_forte_variant(self):
+        """familiar=True on an equipped weapon yields a [Forte] SVY variant."""
+        state, char = _make_state_with_dilettante()
+        _add_equipped(char, _WEAPON_ID, familiar=True)
+        weapons = char.equipped_weapons()
+        forte_entries = [(inv, d) for inv, d in weapons if inv.item_id.endswith("__familiar")]
+        assert len(forte_entries) == 1
+        _, defn = forte_entries[0]
+        assert defn.stat == "savvy"
+
+    def test_forte_variant_name_suffix(self):
+        """[Forte] variant has ' [Forte]' appended to the name."""
+        from engine.data_loader import ITEM_REGISTRY
+        state, char = _make_state_with_dilettante()
+        _add_equipped(char, _WEAPON_ID, familiar=True)
+        weapons = char.equipped_weapons()
+        _, defn = next((inv, d) for inv, d in weapons if inv.item_id.endswith("__familiar"))
+        base_name = ITEM_REGISTRY[_WEAPON_ID].name
+        assert defn.name == f"{base_name} [Forte]"
+
+    def test_forte_variant_item_id_format(self):
+        """Synthetic InventoryItem has item_id '<id>__familiar'."""
+        state, char = _make_state_with_dilettante()
+        _add_equipped(char, _WEAPON_ID, familiar=True)
+        weapons = char.equipped_weapons()
+        inv, _ = next((i, d) for i, d in weapons if i.item_id.endswith("__familiar"))
+        assert inv.item_id == f"{_WEAPON_ID}__familiar"
+
+    def test_forte_variant_absent_without_familiar_flag(self):
+        """No Forte variant when familiar=False."""
+        state, char = _make_state_with_dilettante()
+        _add_equipped(char, _WEAPON_ID, familiar=False)
+        weapons = char.equipped_weapons()
+        assert all(not inv.item_id.endswith("__familiar") for inv, _ in weapons)
+
+    def test_forte_variant_absent_when_not_equipped(self):
+        """familiar=True on an unequipped item does NOT create a Forte variant."""
+        state, char = _make_state_with_dilettante()
+        _add_unequipped(char, _WEAPON_ID, familiar=True)
+        weapons = char.equipped_weapons()
+        assert all(not inv.item_id.endswith("__familiar") for inv, _ in weapons)
+
+    def test_registry_not_mutated(self):
+        """Generating the Forte variant must not mutate the registry definition."""
+        from engine.data_loader import ITEM_REGISTRY
+        original_stat = ITEM_REGISTRY[_WEAPON_ID].stat
+        original_name = ITEM_REGISTRY[_WEAPON_ID].name
+        state, char = _make_state_with_dilettante()
+        _add_equipped(char, _WEAPON_ID, familiar=True)
+        char.equipped_weapons()
+        assert ITEM_REGISTRY[_WEAPON_ID].stat == original_stat
+        assert ITEM_REGISTRY[_WEAPON_ID].name == original_name
+
+    def test_forte_not_generated_when_stat_already_savvy(self):
+        """No redundant [Forte] variant if weapon already uses savvy."""
+        import copy
+
+        from engine.data_loader import ITEM_REGISTRY
+
+        savvy_weapon = copy.copy(ITEM_REGISTRY.get(_WEAPON_ID))
+        savvy_weapon.stat = "savvy"
+        savvy_weapon.name = "SVY Sword"
+        ITEM_REGISTRY["__test_svq_sword"] = savvy_weapon
+
+        state, char = _make_state_with_dilettante()
+        inv = InventoryItem(item_id="__test_svq_sword", equipped=True, familiar=True)
+        char.inventory.append(inv)
+        from engine.azure_constants import ItemSlot
+        char.equipped_slots[ItemSlot.MAIN_HAND.value] = "__test_svq_sword"
+
+        weapons = char.equipped_weapons()
+        assert all(not i.item_id.endswith("__familiar") for i, _ in weapons)
+
+        del ITEM_REGISTRY["__test_svq_sword"]
+
+
+# ---------------------------------------------------------------------------
+# set_familiar_weapon engine function
+# ---------------------------------------------------------------------------
+
+class TestSetFamiliarWeapon:
+    def test_sets_familiar_flag(self):
+        """set_familiar_weapon sets familiar=True on the matching item."""
+        from engine import set_familiar_weapon
+        state, char = _make_state_with_dilettante()
+        inv = _add_unequipped(char, _WEAPON_ID)
+        result = set_familiar_weapon(state, char.character_id, inv.instance_id)
+        assert result.ok
+        assert inv.familiar is True
+
+    def test_one_use_restriction(self):
+        """A second call while a weapon is already familiar returns an error."""
+        from engine import set_familiar_weapon
+        state, char = _make_state_with_dilettante()
+        inv1 = _add_unequipped(char, _WEAPON_ID)
+        inv2 = _add_unequipped(char, _WEAPON_ID)
+        set_familiar_weapon(state, char.character_id, inv1.instance_id)
+        result = set_familiar_weapon(state, char.character_id, inv2.instance_id)
+        assert not result.ok
+        assert inv2.familiar is False
+
+    def test_reset_clears_all_flags(self):
+        """set_familiar_weapon with instance_id=None clears all familiar flags."""
+        from engine import set_familiar_weapon
+        state, char = _make_state_with_dilettante()
+        inv = _add_unequipped(char, _WEAPON_ID)
+        set_familiar_weapon(state, char.character_id, inv.instance_id)
+        assert inv.familiar is True
+        result = set_familiar_weapon(state, char.character_id, None)
+        assert result.ok
+        assert inv.familiar is False
+
+    def test_requires_weapon_forte_skill(self):
+        """Knight without the skill gets an error."""
+        from engine import set_familiar_weapon
+        state, char = _make_state_with_knight()
+        inv = _add_unequipped(char, _WEAPON_ID)
+        result = set_familiar_weapon(state, char.character_id, inv.instance_id)
+        assert not result.ok
+
+    def test_rejects_non_weapon_item(self):
+        """Trying to set a gear item as familiar returns an error."""
+        from engine import set_familiar_weapon
+        from engine.data_loader import ITEM_REGISTRY
+        from engine.item import Gear
+        gear_id = next(k for k, v in ITEM_REGISTRY.items() if isinstance(v, Gear))
+        state, char = _make_state_with_dilettante()
+        inv = InventoryItem(item_id=gear_id)
+        char.inventory.append(inv)
+        result = set_familiar_weapon(state, char.character_id, inv.instance_id)
+        assert not result.ok
+
+    def test_reset_skips_skill_check(self):
+        """DM reset (instance_id=None) works even for a non-Dilettante."""
+        from engine import set_familiar_weapon
+        state, char = _make_state_with_knight()
+        # Manually set a familiar flag to simulate a DM-controlled state
+        inv = _add_unequipped(char, _WEAPON_ID)
+        inv.familiar = True
+        result = set_familiar_weapon(state, char.character_id, None)
+        assert result.ok
+        assert inv.familiar is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: combat hook uses SVY when the __familiar weapon_id is selected
+# ---------------------------------------------------------------------------
+
+class TestForteInCombat:
+    def test_forte_weapon_id_resolves_svq_stat(self):
+        """
+        _hook_weapon_attack uses savvy when weapon_id is '<id>__familiar'.
+        Verified by checking the resolved weapon definition stat.
+        """
+        from engine import add_npc, enter_rounds, open_turn
+        from engine.combat import CombatAction, _hook_weapon_attack
+        from models import NPC, RangeBand
+
+        state, char = _make_state_with_dilettante()
+        _add_equipped(char, _WEAPON_ID, familiar=True)
+
+        npc = NPC(name="Target", hp_current=1000, hp_max=1000)
+        npc_id = npc.npc_id
+        add_npc(state, npc)
+        enter_rounds(state)
+        open_turn(state)
+
+        bf = state.battlefield
+        bf.combatants[char.character_id].range_band = RangeBand.ENGAGE
+        bf.combatants[npc_id].range_band = RangeBand.ENGAGE
+
+        action = CombatAction(
+            action_id="attack",
+            target_id=npc_id,
+            weapon_id=f"{_WEAPON_ID}__familiar",
+        )
+        log: list[str] = []
+        _hook_weapon_attack(state, char.character_id, action, log, {})
+        assert log, "Expected at least one log entry from the hook"
+        assert "no weapon" not in " ".join(log).lower()
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+class TestSerializationRoundTrip:
+    def test_familiar_flag_survives_round_trip(self):
+        """familiar=True on an InventoryItem is preserved through serialize/deserialize."""
+        from serialization import deserialize_inventory_item, serialize_inventory_item
+        inv = InventoryItem(item_id=_WEAPON_ID, familiar=True)
+        data = serialize_inventory_item(inv)
+        assert data["familiar"] is True
+        restored = deserialize_inventory_item(data)
+        assert restored.familiar is True
+
+    def test_familiar_false_survives_round_trip(self):
+        """familiar=False round-trips correctly."""
+        from serialization import deserialize_inventory_item, serialize_inventory_item
+        inv = InventoryItem(item_id=_WEAPON_ID, familiar=False)
+        data = serialize_inventory_item(inv)
+        restored = deserialize_inventory_item(data)
+        assert restored.familiar is False
+
+    def test_missing_familiar_field_defaults_to_false(self):
+        """Old serialized records without 'familiar' key default to False."""
+        from serialization import deserialize_inventory_item
+        data = {
+            "item_id": _WEAPON_ID,
+            "quantity": 1,
+            "equipped": False,
+            "broken": False,
+            "charges": None,
+            "notes": "",
+            "container_id": None,
+            "instance_id": "abc123",
+            # no "familiar" key
+        }
+        restored = deserialize_inventory_item(data)
+        assert restored.familiar is False

--- a/webui/app.py
+++ b/webui/app.py
@@ -24,6 +24,7 @@ from discord_tasks import dispatch_oracle_answer, dispatch_turn_resolved, drain_
 from engine import (
     add_exit,
     adjust_light_charges,
+    adjust_skill_uses,
     adjust_spell_charges,
     answer_oracle,
     apply_condition,
@@ -1234,6 +1235,40 @@ async def route_character_spellrecharge(
         return _char_redirect(char_id, error="Character not found.")
     # Use a large positive delta; adjust_spell_charges clamps to maxCharges.
     result = adjust_spell_charges(state, char.character_id, item_id, delta=9999)
+    if not result.ok:
+        return _char_redirect(char_id, error=result.error)
+    await store.db.save_character_async(char)
+    sync_character_to_sessions(char)
+    return _char_redirect(char_id, flash=result.message)
+
+
+@app.post("/characters/{char_id}/skillcharge", response_class=HTMLResponse)
+async def route_character_skillcharge(
+    char_id: str,
+    skill_id: Annotated[str, Form()],
+    delta: Annotated[int, Form()],
+):
+    state, char = _load_char_state(char_id)
+    if char is None:
+        return _char_redirect(char_id, error="Character not found.")
+    result = adjust_skill_uses(state, char.character_id, skill_id, delta)
+    if not result.ok:
+        return _char_redirect(char_id, error=result.error)
+    await store.db.save_character_async(char)
+    sync_character_to_sessions(char)
+    return _char_redirect(char_id, flash=result.message)
+
+
+@app.post("/characters/{char_id}/skillrecharge", response_class=HTMLResponse)
+async def route_character_skillrecharge(
+    char_id: str,
+    skill_id: Annotated[str, Form()],
+):
+    state, char = _load_char_state(char_id)
+    if char is None:
+        return _char_redirect(char_id, error="Character not found.")
+    # Use a large positive delta; adjust_skill_uses clamps to max_uses.
+    result = adjust_skill_uses(state, char.character_id, skill_id, delta=9999)
     if not result.ok:
         return _char_redirect(char_id, error=result.error)
     await store.db.save_character_async(char)

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -1580,6 +1580,36 @@ def character_sheet_panel(character: Character) -> str:
         )
         return f' {badge}{period_tag} {minus_form}{plus_form}{restore_form}'
 
+    def _skill_charge_controls(skill_id: str, current: int, max_uses: int, recharge_period: str | None = None) -> str:
+        """Return inline uses badge + +/- and restore buttons for limited-use skills."""
+        period_tag_str = ""
+        if recharge_period == "encounter":
+            period_tag_str = ' <span class="muted" style="font-size:0.7rem;border:1px solid #555;border-radius:3px;padding:0 3px" title="Encounter recharge">E</span>'
+        elif recharge_period == "day":
+            period_tag_str = ' <span class="muted" style="font-size:0.7rem;border:1px solid #555;border-radius:3px;padding:0 3px" title="Daily recharge">D</span>'
+        badge = f'<span class="muted" style="font-size:0.8rem">({current}/{max_uses})</span>'
+        minus_form = (
+            f'<form method="post" action="/characters/{cid_str}/skillcharge" style="margin:0;display:inline">'
+            f'<input type="hidden" name="skill_id" value="{skill_id}">'
+            f'<input type="hidden" name="delta" value="-1">'
+            f'<button class="btn-sm" type="submit" style="padding:1px 5px">−</button>'
+            f'</form>'
+        )
+        plus_form = (
+            f'<form method="post" action="/characters/{cid_str}/skillcharge" style="margin:0;display:inline">'
+            f'<input type="hidden" name="skill_id" value="{skill_id}">'
+            f'<input type="hidden" name="delta" value="1">'
+            f'<button class="btn-sm" type="submit" style="padding:1px 5px">+</button>'
+            f'</form>'
+        )
+        restore_form = (
+            f'<form method="post" action="/characters/{cid_str}/skillrecharge" style="margin:0;display:inline">'
+            f'<input type="hidden" name="skill_id" value="{skill_id}">'
+            f'<button class="btn-sm" type="submit" style="padding:1px 5px" title="Restore to max">↺</button>'
+            f'</form>'
+        )
+        return f' {badge}{period_tag_str} {minus_form}{plus_form}{restore_form}'
+
     item_rows = ""
     for inv_item in character.inventory:
         if inv_item.container_id:
@@ -1657,11 +1687,22 @@ def character_sheet_panel(character: Character) -> str:
 
     active_skills = CharacterManager.get_active_skills(character)
     if active_skills:
-        skill_rows = "".join(
-            f'<tr><td style="font-weight:500;white-space:nowrap;padding-right:1rem">{s.name}</td>'
-            f'<td class="muted" style="font-size:0.9rem">{s.description}</td></tr>'
-            for s in active_skills
-        )
+        skill_rows = ""
+        for s in active_skills:
+            if s.uses is not None:
+                job_exp = character.jobs.get(s.source)
+                job_level = job_exp.level if job_exp else character.level
+                max_uses = CharacterManager.get_skill_max_uses(s, job_level)
+                current_uses = character.skill_uses.get(s.skill_id, max_uses)
+                uses_controls = _skill_charge_controls(s.skill_id, current_uses, max_uses, s.recharge_period)
+            else:
+                uses_controls = ""
+            skill_rows += (
+                f'<tr>'
+                f'<td style="font-weight:500;white-space:nowrap;padding-right:1rem">{s.name}{uses_controls}</td>'
+                f'<td class="muted" style="font-size:0.9rem">{s.description}</td>'
+                f'</tr>'
+            )
     else:
         skill_rows = '<tr><td colspan="2" class="muted">None</td></tr>'
     skills_html = f'<table style="margin-bottom:0.75rem">{skill_rows}</table>'


### PR DESCRIPTION
Resolves #139. Add new action "Set Protector Target" and condition "Protected" to implement Knight's protector skill. Actions with the "allies" target setting do not target self by default now