### PR TITLE
Beta dry-run fixes

### DIFF
--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -597,13 +597,19 @@ class CombatActionView(discord.ui.View):
         if state is None:
             return
 
-        # Check if this character has already submitted this round
-        if state.latest_submission(char.character_id) is not None:
-            await interaction.response.send_message(
-                get_string("errors.already_submitted"),
-                ephemeral=True,
-            )
-            return
+        # Block only if the existing submission actually consumes the act.
+        # consumes_act=False submissions (e.g. Set Protector) must not prevent
+        # the player from also choosing an act action.
+        latest = state.latest_submission(char.character_id)
+        if latest is not None:
+            action_id = (latest.combat_action or {}).get("action_id", "")
+            action_def = ACTION_REGISTRY.get(action_id) if action_id else None
+            if action_def is None or action_def.consumes_act:
+                await interaction.response.send_message(
+                    get_string("errors.already_submitted"),
+                    ephemeral=True,
+                )
+                return
 
         view = _build_class_action_view(
             char=char,

--- a/cogs/action_buttons.py
+++ b/cogs/action_buttons.py
@@ -1178,7 +1178,7 @@ class DestinationSelectView(discord.ui.View):
                 return
             await save_session_async(state)
             await interaction.response.edit_message(
-                content=fmt_string("combat.log.moved_to", destination=destination.value.replace('_', ' ')), view=None
+                content=fmt_string("combat.victory.moved_to", destination=destination.value.replace('_', ' ')), view=None
             )
             await update_status(interaction.channel, state)
             return

--- a/cogs/arrive.py
+++ b/cogs/arrive.py
@@ -96,7 +96,7 @@ def format_items_list(slot: str) -> str:
 
     for _item_id, name, price, rank, _rank_type in items:
         rank_label = f" [Rank {rank}]" if rank else ""
-        lines.append(f"\u2022 **{name}**{rank_label} \u2014 {price} gp")
+        lines.append(f"\u2022 **{name}**{rank_label} - {price} gp")
 
     return "\n".join(lines)
 
@@ -137,7 +137,7 @@ def _get_char_ranks(char) -> dict[str, str]:
     ]:
         allowed = cm._char_allowed_ranks(char, rank_type)
         highest = next((r for r in reversed(ordered) if r in allowed), None)
-        result[rank_type] = highest if highest else "\u2014"
+        result[rank_type] = highest if highest else "-"
     return result
 
 
@@ -432,9 +432,9 @@ class ShopView(discord.ui.View):
                 if char is not None and rank:
                     eligible = _item_eligible(char, rank, rank_type)
                     marker = "\u2713" if eligible else "\u2717"
-                    preview_lines.append(f"{marker} **{name}**{rank_label} \u2014 {price} gp")
+                    preview_lines.append(f"{marker} **{name}**{rank_label} - {price} gp")
                 else:
-                    preview_lines.append(f"\u2022 **{name}**{rank_label} \u2014 {price} gp")
+                    preview_lines.append(f"\u2022 **{name}**{rank_label} - {price} gp")
             if len(items) > 10:
                 preview_lines.append(f"... and {len(items) - 10} more")
             items_preview = "\n".join(preview_lines)

--- a/cogs/arrive.py
+++ b/cogs/arrive.py
@@ -242,6 +242,25 @@ class ItemSelectView(discord.ui.View):
             )
             return
 
+        # Light items → collect quantity via modal before purchasing
+        if item.isLight:
+            state = get_session(self.channel_id)
+            current_gold = 0
+            if state is not None:
+                from uuid import UUID
+                with contextlib.suppress(ValueError, AttributeError):
+                    char = state.characters.get(UUID(self.character_id))
+                    current_gold = char.gold if char else 0
+            modal = LightItemQuantityModal(
+                self.channel_id, self.character_id, self.owner_id,
+                self.selected_item_id, item.name,
+                price_per=getattr(item, 'price', 0),
+                current_gold=current_gold,
+                message=interaction.message,
+            )
+            await interaction.response.send_modal(modal)
+            return
+
         # Get the session and character
         state = get_session(self.channel_id)
         if state is None:
@@ -710,6 +729,107 @@ class CharacterNameModal(discord.ui.Modal, title="Enter Character Name"):
                 f"Something went wrong: {error}", ephemeral=True
                 )
 
+
+# ---------------------------------------------------------------------------
+# Light-item quantity modal
+# ---------------------------------------------------------------------------
+
+class LightItemQuantityModal(discord.ui.Modal):
+    """Shown when purchasing a light item — lets the player choose how many to buy."""
+
+    def __init__(
+        self,
+        channel_id: str,
+        character_id: str,
+        owner_id: str,
+        item_id: str,
+        item_name: str,
+        price_per: int,
+        current_gold: int,
+        message: discord.Message,
+    ):
+        super().__init__(title=f"Buy {item_name}"[:45])
+        self.channel_id = channel_id
+        self.character_id = character_id
+        self.owner_id = owner_id
+        self.item_id = item_id
+        self.item_name = item_name
+        self.price_per = price_per
+        self.message = message
+
+        self.qty_input = discord.ui.TextInput(
+            label=f"Quantity ({price_per} gp each · {current_gold} gp available)",
+            placeholder="e.g. 5",
+            min_length=1,
+            max_length=3,
+        )
+        self.add_item(self.qty_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            qty = int(self.qty_input.value.strip())
+        except ValueError:
+            await interaction.response.send_message("⚠ Please enter a valid number.", ephemeral=True)
+            return
+        if qty < 1:
+            await interaction.response.send_message("⚠ Quantity must be at least 1.", ephemeral=True)
+            return
+
+        from uuid import UUID
+        state = get_session(self.channel_id)
+        if state is None:
+            await interaction.response.send_message("⚠ Session no longer exists.", ephemeral=True)
+            return
+        try:
+            char_uuid = UUID(self.character_id)
+        except (ValueError, AttributeError):
+            await interaction.response.send_message("⚠ Invalid character ID.", ephemeral=True)
+            return
+        character = state.characters.get(char_uuid)
+        if character is None:
+            await interaction.response.send_message("⚠ Character not found.", ephemeral=True)
+            return
+
+        total_cost = self.price_per * qty
+        if character.gold < total_cost:
+            await interaction.response.send_message(
+                f"⚠ Not enough gold. You have {character.gold} gp but need {total_cost} gp ({qty}× {self.price_per} gp).",
+                ephemeral=True,
+            )
+            return
+
+        result = give_item(state, char_uuid, self.item_id, quantity=qty)
+        if not result.ok:
+            await interaction.response.send_message(f"⚠ {result.error}", ephemeral=True)
+            return
+
+        character.gold -= total_cost
+        save_session(state)
+
+        await interaction.response.defer()
+        item_def = ITEM_REGISTRY.get(self.item_id)
+        if qty == 1 and isinstance(item_def, EquipItem) and getattr(item_def, 'slot', None):
+            equip_view = EquipNowView(
+                self.channel_id, self.character_id, self.owner_id,
+                self.item_id, self.item_name, character.gold,
+            )
+            await self.message.edit(
+                content=fmt_string(
+                    "shop.purchased_equip_prompt",
+                    name=self.item_name, price=total_cost, remaining_gold=character.gold,
+                ),
+                view=equip_view,
+            )
+        else:
+            shop_view = ShopView(self.channel_id, self.character_id, self.owner_id)
+            await self.message.edit(
+                content=fmt_string(
+                    "shop.purchased_bulk",
+                    qty=qty, name=self.item_name,
+                    total_price=total_cost, remaining_gold=character.gold,
+                ),
+                view=shop_view,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/cogs/character_views.py
+++ b/cogs/character_views.py
@@ -165,7 +165,7 @@ def _character_sheet(char, state) -> str:
     svy = char.effective_stat("savvy")
     sheet_lines = [
         sep,
-        f"{char.name}  \u2014  {char.character_class.value} Level {char.level}{leader_note}",
+        f"{char.name}  -  {char.character_class.value} Level {char.level}{leader_note}",
         f"HP: {char.hp_current}/{char.hp_max}   DEF: {char.defense} RES: {char.resistance}  Move: {char.movement_speed}'",
         f"XP: {char.experience}   Gold: {char.gold} gp",
         sep,

--- a/data/conditions/asleep.json
+++ b/data/conditions/asleep.json
@@ -1,0 +1,12 @@
+{
+  "condition_id": "asleep",
+  "label": "Asleep",
+  "duration_type": "rounds",
+  "stackable": false,
+  "hooks": {
+    "on_turn_start": "skip_action",
+    "on_turn_end": {"tag": "remove_this_condition_on_roll", "dice": "1d4", "threshold": 4}
+  },
+  "stat_modifiers": {},
+  "grants_actions": []
+}

--- a/data/example_dungeon/the_gauntlet.json
+++ b/data/example_dungeon/the_gauntlet.json
@@ -9,7 +9,7 @@
       "ba8d77a2-9b69-46cf-992a-5a4cd963e80a": {
         "room_id": "ba8d77a2-9b69-46cf-992a-5a4cd963e80a",
         "name": "Lower Gates of the Keep",
-        "description": "On the western side of the fortress, the wall which looms up from the track to the battlemented area has two large, tower-like buttresses.As you round the first of these, you find an impressive gateway occupying most of the width of the wall between them.",
+        "description": "On the western side of the fortress, the wall which looms up from the track to the battlemented area has two large, tower-like buttresses. As you round the first of these, you find an impressive gateway occupying most of the width of the wall between them.",
         "notes": "Adventurers can enter through the lower gates undetected.",
         "features": [
           {
@@ -711,7 +711,255 @@
     "entrance_id": "ba8d77a2-9b69-46cf-992a-5a4cd963e80a",
     "random_encounter_interval": 6,
     "random_encounter_roll": "1d6",
-    "random_encounter_roster": []
+    "random_encounter_roster": [
+      {
+        "npc_group": {
+          "group_id": "619a0496-41f6-4578-8607-4e8c42396ff8",
+          "name": "Gnoll Battlegroup",
+          "npcs": [
+            {
+              "npc_id": "c32ac895-17b9-46cd-9542-bc15354304bb",
+              "name": "Gnoll A",
+              "description": "",
+              "hp_max": 400,
+              "hp_current": 400,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "4d100",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 0,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            },
+            {
+              "npc_id": "06aa3ad3-df59-4d1c-a498-a4797d720e20",
+              "name": "Gnoll Archer A",
+              "description": "",
+              "hp_max": 400,
+              "hp_current": 400,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "2d300",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 2,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            },
+            {
+              "npc_id": "c00fe8d7-3e88-4683-b28c-a7827ebf25b3",
+              "name": "Gnoll Archer B",
+              "description": "",
+              "hp_max": 400,
+              "hp_current": 400,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "2d300",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 2,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            }
+          ],
+          "possible_rooms": [],
+          "movement_logic": "stationary",
+          "current_room_id": null,
+          "patrol_route": []
+        },
+        "weight": 1
+      },
+      {
+        "npc_group": {
+          "group_id": "6db12c90-2363-4d3e-a420-23e4cbae498a",
+          "name": "Worker Ants",
+          "npcs": [
+            {
+              "npc_id": "d88ec237-31fa-4b87-bbc7-5735e9315f70",
+              "name": "Worker Ant A",
+              "description": "",
+              "hp_max": 200,
+              "hp_current": 200,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "4d100",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 0,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            },
+            {
+              "npc_id": "7b8b56ef-8dfc-4fb0-86c8-f53e67255c28",
+              "name": "Worker Ant B",
+              "description": "",
+              "hp_max": 200,
+              "hp_current": 200,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "4d100",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 0,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            }
+          ],
+          "possible_rooms": [],
+          "movement_logic": "stationary",
+          "current_room_id": null,
+          "patrol_route": []
+        },
+        "weight": 1
+      },
+      {
+        "npc_group": {
+          "group_id": "fc477a50-4f36-49fc-988c-9111a8ffce24",
+          "name": "Gnoll Battlegroup",
+          "npcs": [
+            {
+              "npc_id": "cde06226-10b8-4e3e-8c32-dea229a4eabd",
+              "name": "Gnoll A",
+              "description": "",
+              "hp_max": 400,
+              "hp_current": 400,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "4d100",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 0,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            },
+            {
+              "npc_id": "6f6c42a5-23ab-4c49-a8b7-4503cbcbe8ca",
+              "name": "Gnoll B",
+              "description": "",
+              "hp_max": 400,
+              "hp_current": 400,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "4d100",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 0,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            },
+            {
+              "npc_id": "95a65d64-86a4-4937-996c-36c819f95f3a",
+              "name": "Gnoll C",
+              "description": "",
+              "hp_max": 400,
+              "hp_current": 400,
+              "defense": 0,
+              "resistance": 0,
+              "ability_scores": {
+                "physique": 0,
+                "finesse": 0,
+                "reason": 0,
+                "savvy": 0
+              },
+              "movement_speed": 90,
+              "attack_bonus": 0,
+              "damage_dice": "4d100",
+              "morale": 7,
+              "saving_throw": 15,
+              "hit_dice": 2,
+              "weapon_range": 0,
+              "status": "active",
+              "notes": "",
+              "active_conditions": [],
+              "hidden": false
+            }
+          ],
+          "possible_rooms": [],
+          "movement_logic": "stationary",
+          "current_room_id": null,
+          "patrol_route": []
+        },
+        "weight": 1
+      }
+    ]
   },
   "npc_roster": {
     "groups": {
@@ -1121,7 +1369,7 @@
       },
       "6a07285b-843d-4a76-b724-b2c9ccd80b66": {
         "group_id": "6a07285b-843d-4a76-b724-b2c9ccd80b66",
-        "name": null,
+        "name": "Gnoll Battlegroup",
         "npcs": [
           {
             "npc_id": "cf0977da-d858-4d35-99f8-81cfabf93443",

--- a/data/example_dungeon/the_gauntlet.json
+++ b/data/example_dungeon/the_gauntlet.json
@@ -41,7 +41,7 @@
       "b20a22a5-7ce4-4a29-8780-581e520036c1": {
         "room_id": "b20a22a5-7ce4-4a29-8780-581e520036c1",
         "name": "The Gateway of Berghof",
-        "description": "This is a large and impressive room. The walls and ceiling are of a deep red, lustrous stone, flecked with glittering white inclusions. The floor is of a smooth, pale grey stone and has a large coat of arms inlaid in its centre.\nIn an alcove in each corner of the room stands a large stone chair. Three of the chairs are occupied by strange, silent, unmoving figures which appear to be no more than suits of human-sized clothing, arranged as if worn by invisible, seated men. The chair in the south-eastern alcove is empty.",
+        "description": "This is a large and impressive room. The walls and ceiling are of a deep red, lustrous stone, flecked with glittering white inclusions. The floor is of a smooth, pale grey stone and has a large coat of arms inlaid in its center. In an alcove in each corner of the room stands a large stone chair. Three of the chairs are occupied by strange, silent, unmoving figures which appear to be no more than suits of human-sized clothing, arranged as if worn by invisible, seated men. The chair in the south-eastern alcove is empty.",
         "notes": "",
         "features": [
           {
@@ -134,7 +134,7 @@
       "e2e53dbb-80b8-435f-a255-6789265bc059": {
         "room_id": "e2e53dbb-80b8-435f-a255-6789265bc059",
         "name": "Guardian's Hall",
-        "description": "This long hall appears to beempty but you cannot see the far end since it is obscured by an uneven screen of a paper-like material. The floor consists of green, red\nand white hexagonal tiles, each about 6 inches across, laid out in a regular pattern. The walls are pale grey and plain, as is the ceiling.",
+        "description": "This long hall appears to be empty but you cannot see the far end since it is obscured by an uneven screen of a paper-like material. The floor consists of green, red and white hexagonal tiles, each about 6 inches across, laid out in a regular pattern. The walls are pale grey and plain, as is the ceiling.",
         "notes": "",
         "features": [],
         "exits": [
@@ -169,7 +169,7 @@
       "caba1f5f-8876-446c-80c0-cfba1db259a2": {
         "room_id": "caba1f5f-8876-446c-80c0-cfba1db259a2",
         "name": "Guardian's Hall (b)",
-        "description": "Beyond the screen you find another section of the room but the far end is still obscured since there is a second screen. This is similar to the first except that\nthere is a small hole in it near the floor.\nThere are five giant ants working here",
+        "description": "Beyond the screen you find another section of the room but the far end is still obscured since there is a second screen. This is similar to the first except that there is a small hole in it near the floor. There are five giant ants working here",
         "notes": "",
         "features": [
           {
@@ -337,7 +337,7 @@
       "8723bd17-4b1c-4b5d-9a99-bac407ca5d24": {
         "room_id": "8723bd17-4b1c-4b5d-9a99-bac407ca5d24",
         "name": "Release Chamber",
-        "description": "This room is circular and seems to be unoccupied. With the exception of a circular area in the center of the floor, the walls, floor and ceiling are of a smooth\npale grey stone. The circular area contains a stark spiral pattern in black and white",
+        "description": "This room is circular and seems to be unoccupied. With the exception of a circular area in the center of the floor, the walls, floor and ceiling are of a smooth pale grey stone. The circular area contains a stark spiral pattern in black and white",
         "notes": "Room 9",
         "features": [],
         "exits": [

--- a/data/example_dungeon/the_gauntlet.json
+++ b/data/example_dungeon/the_gauntlet.json
@@ -644,7 +644,7 @@
             "exit_id": "9de11c21-744f-4c05-93e5-b1ed8af7033b",
             "label": "Reinforced wooden door (S)",
             "direction": null,
-            "destination_id": "64bd649c-d929-4562-8591-09bbf4db8230",
+            "destination_id": "9ccf9bf1-0040-4e1c-9d95-6c3455bccd50",
             "door_state": "closed",
             "auto_move": false,
             "description": "An iron-barred wooden door leading south, positioned behind the southern gate of metal bars.",

--- a/data/example_dungeon/the_gauntlet.json
+++ b/data/example_dungeon/the_gauntlet.json
@@ -1280,7 +1280,15 @@
             "weapon_range": 0,
             "status": "asleep",
             "notes": "",
-            "active_conditions": [],
+            "active_conditions": [
+              {
+                "condition_id": "asleep",
+                "duration_rounds": null,
+                "source_id": null,
+                "stacks": 1,
+                "applied_this_turn": false
+              }
+            ],
             "hidden": false
           },
           {
@@ -1306,7 +1314,15 @@
             "weapon_range": 0,
             "status": "asleep",
             "notes": "",
-            "active_conditions": [],
+            "active_conditions": [
+              {
+                "condition_id": "asleep",
+                "duration_rounds": null,
+                "source_id": null,
+                "stacks": 1,
+                "applied_this_turn": false
+              }
+            ],
             "hidden": false
           },
           {
@@ -1332,7 +1348,15 @@
             "weapon_range": 0,
             "status": "asleep",
             "notes": "",
-            "active_conditions": [],
+            "active_conditions": [
+              {
+                "condition_id": "asleep",
+                "duration_rounds": null,
+                "source_id": null,
+                "stacks": 1,
+                "applied_this_turn": false
+              }
+            ],
             "hidden": false
           },
           {
@@ -1659,7 +1683,7 @@
       },
       "435bbe2f-be05-4c9a-993d-e0912798e0d1": {
         "group_id": "435bbe2f-be05-4c9a-993d-e0912798e0d1",
-        "name": null,
+        "name": "Guardroom Gnolls",
         "npcs": [
           {
             "npc_id": "83daa3ac-27a4-48c7-b627-465cc013c9b2",

--- a/data/jobskills/skills.json
+++ b/data/jobskills/skills.json
@@ -123,7 +123,7 @@
     "knight_protector": {
       "name": "Protector",
       "type": 2,
-      "desc": "Give +100 DEF to one other party member. Bonus scales to +200 at L3 and +300 at L5. Oracle action \u2014 usable once per round.",
+      "desc": "Give +100 DEF to one other party member. Bonus scales to +200 at L3 and +300 at L5. Oracle action (usable once per round).",
       "action_id": "set_protector_target"
     },
     "knight_rep": {

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -182,6 +182,12 @@ combat:
     no_action: "The round passes without incident."
     stunned: "{actor_name} is stunned and cannot act this round!"
     action_out_of_range: "{actor_name} cannot use {label} from {band}, target is {dist} band(s) away (max {max_range})."
+  victory:
+    header: "**Victory!**"
+    npc_row: "  • {npc_name}: {xp} XP"
+    total_xp: "**Total XP earned:** {xp_total} ({xp_each} each, {party_size} adventurers)"
+    level_up: "{name} reached level {level}!"
+    footer: "The party returns to exploration."
     oracle_already_used: "{actor_name} has already used their oracle action this round."
     moved_to: "Moved to **{destination}**."
   condition:

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -235,6 +235,7 @@ shop:
   insufficient_gold: "Not enough gold. You have {gold} gp, but need {price} gp."
   purchased_equip_prompt: "Purchased **{name}** for {price} gp.\nYou have {remaining_gold} gp remaining.\n\nWould you like to equip **{name}** now?"
   purchased_continue: "Purchased **{name}** for {price} gp.\nYou have {remaining_gold} gp remaining.\n\n**Item Shop** -  Select a category to continue shopping:"
+  purchased_bulk: "Purchased {qty}× **{name}** for {total_price} gp.\nYou have {remaining_gold} gp remaining.\n\n**Item Shop** \u00b7 Select a category to continue shopping:"
   browse_prompt: "**Item Shop**: {remaining_gold} gp remaining. Select a category:"
   slot_items_preview: "**{slot} Items**\n\n{char_ranks_line}\n{items_preview}\n\nSelect an item to purchase:"
   welcome: "**Item Shop**\n\nYou can browse and purchase starting equipment for **{name}**.\nSelect a category to see available items:"

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -233,7 +233,7 @@ shop:
   item_selected: "**Selected:** {name} ({price} gp)\n\nClick 'Buy' to purchase this item."
   insufficient_gold: "Not enough gold. You have {gold} gp, but need {price} gp."
   purchased_equip_prompt: "Purchased **{name}** for {price} gp.\nYou have {remaining_gold} gp remaining.\n\nWould you like to equip **{name}** now?"
-  purchased_continue: "Purchased **{name}** for {price} gp.\nYou have {remaining_gold} gp remaining.\n\n**Item Shop** \u2014 Select a category to continue shopping:"
+  purchased_continue: "Purchased **{name}** for {price} gp.\nYou have {remaining_gold} gp remaining.\n\n**Item Shop** -  Select a category to continue shopping:"
   browse_prompt: "**Item Shop**: {remaining_gold} gp remaining. Select a category:"
   slot_items_preview: "**{slot} Items**\n\n{char_ranks_line}\n{items_preview}\n\nSelect an item to purchase:"
   welcome: "**Item Shop**\n\nYou can browse and purchase starting equipment for **{name}**.\nSelect a category to see available items:"

--- a/data/strings.yaml
+++ b/data/strings.yaml
@@ -179,6 +179,7 @@ combat:
     stat_check_failure: "{actor_name} rolls {roll} + {stat_value} = {total} vs DC {dc} — failed."
     condition_expired: "{name}'s {cond_name} condition has expired."
     condition_removed: "{name} is no longer {cond_name}."
+    wake_roll_failed: "{name} rolls {roll} (need {threshold}) — still {cond_name}."
     no_action: "The round passes without incident."
     stunned: "{actor_name} is stunned and cannot act this round!"
     action_out_of_range: "{actor_name} cannot use {label} from {band}, target is {dist} band(s) away (max {max_range})."

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -771,8 +771,11 @@ def render_status(state: GameState) -> str:
             elif char.status_notes:
                 status_tag = f", {char.status_notes}"
 
-            submission = state.latest_submission(cid)
-            sub_text = f" (\"{submission.action_text}\")" if submission else ""
+            active_subs = [
+                s for s in (state.current_turn.submissions if state.current_turn else [])
+                if s.character_id == cid and s.is_latest
+            ]
+            sub_text = f" (\"{'; '.join(s.action_text for s in active_subs)}\")" if active_subs else ""
 
             cls_name = char.character_class.value
             lines.append(

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -281,6 +281,68 @@ def copy_npc(state: GameState, npc_id, room_id=None):
     return nm.copy_npc(state, npc_id, room_id=room_id)
 
 
+def add_npc_to_group(state: GameState, group_id, npc):
+    """Add an NPC directly to a specific group."""
+    nm = NPCManager()
+    return nm.add_npc_to_group(state, group_id, npc)
+
+
+def update_group(state: GameState, group_id, name, movement_logic, current_room_id, possible_rooms):
+    """Update group-level properties."""
+    nm = NPCManager()
+    return nm.update_group(state, group_id, name, movement_logic, current_room_id, possible_rooms)
+
+
+def remove_npc_group_by_id(state: GameState, group_id):
+    """Remove an NPC group by its group_id."""
+    nm = NPCManager()
+    return nm.remove_npc_group(state, group_id)
+
+
+def add_encounter_entry(state: GameState, npc_group_template, weight: int):
+    """Add an encounter entry to the dungeon's random encounter roster."""
+    nm = NPCManager()
+    return nm.add_encounter_entry(state, npc_group_template, weight)
+
+
+def remove_encounter_entry(state: GameState, group_id):
+    """Remove an encounter entry by its template group_id."""
+    nm = NPCManager()
+    return nm.remove_encounter_entry(state, group_id)
+
+
+def update_encounter_entry_weight(state: GameState, group_id, weight: int):
+    """Update an encounter entry's weight."""
+    nm = NPCManager()
+    return nm.update_encounter_entry_weight(state, group_id, weight)
+
+
+def promote_group_to_encounter(state: GameState, group_id, weight: int):
+    """Promote a live NPC group to the random encounter roster."""
+    nm = NPCManager()
+    return nm.promote_group_to_encounter(state, group_id, weight)
+
+
+def update_encounter_npc(state: GameState, encounter_group_id, npc_id, name, description, hp_max,
+                         defense, notes="", hit_dice=1, resistance=0, weapon_range=0, damage_dice="1d6"):
+    """Update an NPC in an encounter template group."""
+    nm = NPCManager()
+    return nm.update_encounter_npc(state, encounter_group_id, npc_id, name, description, hp_max,
+                                   defense, notes, hit_dice, resistance, weapon_range, damage_dice)
+
+
+def remove_encounter_npc(state: GameState, encounter_group_id, npc_id):
+    """Remove an NPC from an encounter template group."""
+    nm = NPCManager()
+    return nm.remove_encounter_npc(state, encounter_group_id, npc_id)
+
+
+def add_npc_to_encounter_group(state: GameState, encounter_group_id, npc):
+    """Add an NPC to an encounter template group."""
+    nm = NPCManager()
+    return nm.add_npc_to_encounter_group(state, encounter_group_id, npc)
+
+
 def open_turn(state: GameState, due_at=None):
     """Open a new turn."""
     tm = TurnManager()
@@ -863,6 +925,16 @@ __all__ = [
     "import_dungeon",
     "update_dungeon",
     "copy_npc",
+    "add_npc_to_group",
+    "update_group",
+    "remove_npc_group_by_id",
+    "add_encounter_entry",
+    "remove_encounter_entry",
+    "update_encounter_entry_weight",
+    "promote_group_to_encounter",
+    "update_encounter_npc",
+    "remove_encounter_npc",
+    "add_npc_to_encounter_group",
     "abscond",
     "render_status_header",
     "render_status",

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -235,6 +235,12 @@ def set_npc_visibility(state: GameState, npc_id, hidden: bool):
     return nm.set_npc_visibility(state, npc_id, hidden)
 
 
+def remove_npc_condition(state: GameState, npc_id, condition_id: str):
+    """Remove a named condition from an NPC in the roster."""
+    nm = NPCManager()
+    return nm.remove_npc_condition(state, npc_id, condition_id)
+
+
 def remove_npc_group(state: GameState, npc_id):
     """Remove an NPC by removing its group."""
     nm = NPCManager()
@@ -897,6 +903,7 @@ __all__ = [
     "set_npc_hp",
     "set_npc_status",
     "remove_npc",
+    "remove_npc_condition",
     "update_npc",
     "open_turn",
     "submit_turn",

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -398,6 +398,44 @@ def auto_resolve_round(state: GameState) -> object:  # EngineResult
     if bf.abscond_succeeded:
         from engine.session import SessionManager  # local import avoids circular dep
         SessionManager().exit_rounds(state)
+        return _ok(state, narrative)
+
+    # If all NPC combatants are gone, distribute deferred XP and exit combat.
+    remaining_npc_combatants = any(not cs.is_player for cs in bf.combatants.values())
+    if not remaining_npc_combatants and bf.defeated_npc_log:
+        from engine.character import CharacterManager
+        from engine.session import SessionManager
+        from models import CharacterStatus
+
+        total_xp = sum(xp for _, xp in bf.defeated_npc_log)
+        active = [c for c in state.characters.values()
+                  if c.status == CharacterStatus.ACTIVE]
+        if active and total_xp > 0:
+            level_ups = CharacterManager().distribute_xp(state, total_xp)
+            xp_each = total_xp // len(active)
+        else:
+            level_ups = []
+            xp_each = 0
+
+        victory_lines = [get_string("combat.victory.header")]
+        for npc_name, npc_xp in bf.defeated_npc_log:
+            victory_lines.append(
+                fmt_string("combat.victory.npc_row", npc_name=npc_name, xp=npc_xp)
+            )
+        if total_xp > 0:
+            victory_lines.append(
+                fmt_string("combat.victory.total_xp",
+                           xp_total=total_xp, xp_each=xp_each, party_size=len(active))
+            )
+        for lu in level_ups:
+            victory_lines.append(
+                fmt_string("combat.victory.level_up",
+                           name=lu.character_name, level=lu.new_level)
+            )
+        victory_lines.append(get_string("combat.victory.footer"))
+
+        SessionManager().exit_rounds(state)
+        narrative = narrative + "\n\n" + "\n".join(victory_lines)
 
     return _ok(state, narrative)
 

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -516,7 +516,7 @@ def _npc_decide(
     npc_id: UUID,
     cs:     CombatantState,
 ) -> CombatAction | None:
-    """Simple NPC AI: move toward players if far; attack lowest-HP player if in range."""
+    """NPC AI: move toward the nearest player; attack if in range. Ties broken by lowest HP."""
     living_players = [
         (cid, pcs) for cid, pcs in state.battlefield.combatants.items()
         if pcs.is_player and _is_alive(state, cid)
@@ -525,15 +525,16 @@ def _npc_decide(
     if not living_players:
         return None
 
-    npc_obj       = _find_npc(state, npc_id)
-    npc_range     = npc_obj.weapon_range if npc_obj else 0
-    target_id = _lowest_hp_player(state, living_players)
-    if target_id:
-        target_cs = state.battlefield.combatants.get(target_id)
-        if target_cs and _band_distance(cs.range_band, target_cs.range_band) <= npc_range:
-            return CombatAction(action_id="attack", target_id=target_id)
+    npc_obj   = _find_npc(state, npc_id)
+    npc_range = npc_obj.weapon_range if npc_obj else 0
 
-    move_target = target_cs.range_band if target_id and target_cs else RangeBand.ENGAGE
+    target_id = _nearest_player(state, cs.range_band, living_players)
+    target_cs = state.battlefield.combatants.get(target_id) if target_id else None
+
+    if target_id and target_cs and _band_distance(cs.range_band, target_cs.range_band) <= npc_range:
+        return CombatAction(action_id="attack", target_id=target_id)
+
+    move_target = target_cs.range_band if target_cs else RangeBand.ENGAGE
     destination = _step_toward(cs.range_band, move_target)
     if destination != cs.range_band:
         return CombatAction(action_id="move", destination=destination)
@@ -564,4 +565,20 @@ def _lowest_hp_player(
         if char and char.hp_current < best_hp:
             best_hp = char.hp_current
             best_id = cid
+    return best_id
+
+
+def _nearest_player(
+    state:          GameState,
+    from_band:      RangeBand,
+    living_players: list[tuple[UUID, CombatantState]],
+) -> UUID | None:
+    """Return the nearest player by band distance; break ties by lowest HP."""
+    best_id, best_dist, best_hp = None, float("inf"), float("inf")
+    for cid, pcs in living_players:
+        dist = _band_distance(from_band, pcs.range_band)
+        char = state.characters.get(cid)
+        hp   = char.hp_current if char else float("inf")
+        if dist < best_dist or (dist == best_dist and hp < best_hp):
+            best_id, best_dist, best_hp = cid, dist, hp
     return best_id

--- a/engine/combat_hooks.py
+++ b/engine/combat_hooks.py
@@ -421,15 +421,7 @@ def _hook_check_death(
         state.battlefield.combatants.pop(target_id, None)
         xp_total = target_npc.hit_dice * 100
         if xp_total > 0:
-            from engine.character import CharacterManager
-            from models import CharacterStatus
-            active = [c for c in state.characters.values()
-                      if c.status == CharacterStatus.ACTIVE]
-            if active:
-                cm = CharacterManager()
-                cm.distribute_xp(state, xp_total)
-                xp_each = xp_total // len(active)
-                log.append(fmt_string("combat.log.xp_gained", xp_total=xp_total, xp_each=xp_each))
+            state.battlefield.defeated_npc_log.append((target_name, xp_total))
 
 
 def _opportunity_attacks(

--- a/engine/combat_hooks.py
+++ b/engine/combat_hooks.py
@@ -267,7 +267,7 @@ def _hook_weapon_attack(
     actor_cs  = state.battlefield.combatants.get(actor_id)
     target_cs = state.battlefield.combatants.get(target_id)
     if actor_cs and target_cs:
-        weapon_range = 0  # default: melee (also used for NPCs without equipped weapons)
+        weapon_range = 0  # default: melee
         maybe_char = state.characters.get(actor_id)
         if maybe_char:
             weapons = maybe_char.equipped_weapons()
@@ -281,6 +281,10 @@ def _hook_weapon_attack(
                     if w_pair:
                         _, w_def = w_pair
                 weapon_range = getattr(w_def, "range", 0)
+        else:
+            maybe_npc = _find_npc(state, actor_id)
+            if maybe_npc:
+                weapon_range = maybe_npc.weapon_range
         from engine.combat import _band_distance
         dist = _band_distance(actor_cs.range_band, target_cs.range_band)
         if dist > weapon_range:

--- a/engine/combat_hooks.py
+++ b/engine/combat_hooks.py
@@ -706,6 +706,50 @@ def _hook_remove_condition(
         log.append(fmt_string("combat.log.condition_removed", name=_combatant_name(state, actor_id), cond_name=label))
 
 
+def _hook_remove_this_condition_on_roll(
+    state:    GameState,
+    actor_id: UUID,
+    action,              # CombatAction | None
+    log:      list[str],
+    params:   dict,
+) -> None:
+    """
+    Roll dice at on_turn_end; remove the parent condition if total >= threshold.
+
+    params (from JSON):
+      dice      (str, default "1d4") — dice expression to roll
+      threshold (int, default 4)    — minimum roll required to remove the condition
+    params (injected by _tick_actor_conditions, not from JSON):
+      _condition_id (str) — condition_id of the condition this hook belongs to
+    """
+    dice         = params.get("dice", "1d4")
+    threshold    = int(params.get("threshold", 4))
+    condition_id = params.get("_condition_id", "")
+
+    if not condition_id:
+        log.append("[remove_this_condition_on_roll: _condition_id not injected — skipped]")
+        return
+
+    roll     = roll_dice_expr(dice)["total"]
+    cond_def = CONDITION_REGISTRY.get(condition_id)
+    label    = cond_def.label if cond_def else condition_id
+    name     = _combatant_name(state, actor_id)
+
+    if roll >= threshold:
+        combatant = state.characters.get(actor_id) or _find_npc(state, actor_id)
+        if combatant is not None:
+            combatant.active_conditions = [
+                c for c in combatant.active_conditions
+                if c.condition_id != condition_id
+            ]
+        log.append(fmt_string("combat.log.condition_removed", name=name, cond_name=label))
+    else:
+        log.append(fmt_string(
+            "combat.log.wake_roll_failed",
+            name=name, cond_name=label, roll=roll, threshold=threshold,
+        ))
+
+
 def _hook_skip_action(
     state:    GameState,
     actor_id: UUID,
@@ -936,10 +980,11 @@ _HOOK_DISPATCH: dict[str, object] = {
     "move_to_band":    _hook_move_to_band,
     "block_movement":  _hook_block_movement,
     # Conditions
-    "apply_condition":  _hook_apply_condition,
-    "remove_condition": _hook_remove_condition,
-    "deal_damage":      _hook_deal_damage,
-    "skip_action":      _hook_skip_action,
+    "apply_condition":              _hook_apply_condition,
+    "remove_condition":             _hook_remove_condition,
+    "remove_this_condition_on_roll": _hook_remove_this_condition_on_roll,
+    "deal_damage":                  _hook_deal_damage,
+    "skip_action":                  _hook_skip_action,
     # Flee
     "abscond_roll":    _hook_abscond_roll,
     # General stat check
@@ -990,7 +1035,18 @@ def _tick_actor_conditions(state: GameState, actor_id: UUID, log: list[str]) -> 
         if cond_def:
             entry = cond_def.hooks.get("on_turn_end")
             if entry:
-                _dispatch_hook(entry, state, actor_id, None, log)
+                # Inject _condition_id so remove_this_condition_on_roll can identify
+                # which condition it belongs to without a redundant JSON param.
+                if isinstance(entry, dict):
+                    dispatched = {**entry, "_condition_id": cond.condition_id}
+                else:
+                    dispatched = {"tag": entry, "_condition_id": cond.condition_id}
+                _dispatch_hook(dispatched, state, actor_id, None, log)
+
+        # If the hook self-removed this condition, combatant.active_conditions is
+        # now a new filtered list. Skip duration tracking to avoid resurrecting it.
+        if not any(c is cond for c in combatant.active_conditions):
+            continue
 
         if cond.duration_rounds is None:
             still_active.append(cond)

--- a/engine/core.py
+++ b/engine/core.py
@@ -192,7 +192,10 @@ class TurnManager:
         state.current_turn  = None
         state.say_log       = []
         state.oracle_counter = 0
-        state.turn_number   += 1
+        # exit_rounds (called on victory or abscond) already set turn_number;
+        # only increment here when still in ROUNDS mode (combat continues).
+        if state.mode == SessionMode.ROUNDS:
+            state.turn_number += 1
         state.updated_at    = _now()
 
         # Open the next round immediately so the status message shows an open

--- a/engine/light.py
+++ b/engine/light.py
@@ -24,7 +24,11 @@ def _tick_light(state: GameState) -> None:
                 (i for i in char.inventory if i.item_id == item_id and i.equipped),
                 None,
             )
-            if inv_item is None or inv_item.charges is None or inv_item.charges <= 0:
+            if inv_item is None or inv_item.charges is None:
+                continue
+            if inv_item.charges <= 0:
+                # Dark lantern with fuel now available (e.g. equipped before oil was bought).
+                _handle_light_burnout(state, char, inv_item, defn)
                 continue
             inv_item.charges -= 1
             if inv_item.charges <= 0:

--- a/engine/npc.py
+++ b/engine/npc.py
@@ -3,9 +3,9 @@ NPC management for the dungeon crawler engine.
 """
 
 import copy
-from uuid import uuid4
+from uuid import UUID, uuid4
 
-from models import NPC, GameState, NPCGroup, NPCMovementLogic
+from models import NPC, EncounterEntry, GameState, NPCGroup, NPCMovementLogic
 from validation import validate_hp_value, validate_non_empty_string
 
 from .helpers import _err, _find_npc_in_roster, _find_npcgroup_with_npc, _now, _ok
@@ -249,3 +249,147 @@ class NPCManager:
         new_npc.name = raw_name[:50]
 
         return self.add_npc_to_room(state, new_npc, room_id=target_room)
+
+    def add_npc_to_group(self, state: GameState, group_id: UUID, npc: NPC):
+        """Add an NPC directly to a specific existing group."""
+        group = state.npc_roster.get_group(group_id)
+        if group is None:
+            return _err(state, fmt_string("npc.errors.group_not_found", group_id=group_id))
+        group.npcs.append(npc)
+        state.updated_at = _now()
+        return _ok(state, fmt_string("npc.appears", name=npc.name))
+
+    def update_group(
+        self,
+        state: GameState,
+        group_id: UUID,
+        name: str | None,
+        movement_logic: NPCMovementLogic,
+        current_room_id: UUID | None,
+        possible_rooms: list[UUID],
+    ):
+        """Update group-level properties."""
+        group = state.npc_roster.get_group(group_id)
+        if group is None:
+            return _err(state, fmt_string("npc.errors.group_not_found", group_id=group_id))
+        group.name = name or None
+        group.movement_logic = movement_logic
+        group.current_room_id = current_room_id
+        group.possible_rooms = possible_rooms
+        state.updated_at = _now()
+        return _ok(state, "Group updated.")
+
+    def add_encounter_entry(self, state: GameState, npc_group_template: NPCGroup, weight: int):
+        """Append a new entry to the dungeon's random encounter roster."""
+        if state.dungeon is None:
+            return _err(state, "No dungeon loaded.")
+        weight = max(1, int(weight))
+        entry = EncounterEntry(npc_group=npc_group_template, weight=weight)
+        state.dungeon.random_encounter_roster.append(entry)
+        state.updated_at = _now()
+        group_name = npc_group_template.name or "Unnamed group"
+        return _ok(state, f"Added '{group_name}' to encounter roster.")
+
+    def remove_encounter_entry(self, state: GameState, group_id: UUID):
+        """Remove the encounter entry whose template group_id matches."""
+        if state.dungeon is None:
+            return _err(state, "No dungeon loaded.")
+        roster = state.dungeon.random_encounter_roster
+        for i, entry in enumerate(roster):
+            if entry.npc_group.group_id == group_id:
+                del roster[i]
+                state.updated_at = _now()
+                return _ok(state, "Encounter entry removed.")
+        return _err(state, "Encounter entry not found.")
+
+    def update_encounter_entry_weight(self, state: GameState, group_id: UUID, weight: int):
+        """Update the weight of an encounter entry identified by its template group_id."""
+        if state.dungeon is None:
+            return _err(state, "No dungeon loaded.")
+        for entry in state.dungeon.random_encounter_roster:
+            if entry.npc_group.group_id == group_id:
+                entry.weight = max(1, int(weight))
+                state.updated_at = _now()
+                return _ok(state, "Encounter weight updated.")
+        return _err(state, "Encounter entry not found.")
+
+    def promote_group_to_encounter(self, state: GameState, group_id: UUID, weight: int):
+        """Deep-copy a live group and add it as an encounter roster template."""
+        group = state.npc_roster.get_group(group_id)
+        if group is None:
+            return _err(state, fmt_string("npc.errors.group_not_found", group_id=group_id))
+        template = copy.deepcopy(group)
+        template.group_id = uuid4()
+        for npc in template.npcs:
+            npc.npc_id = uuid4()
+            npc.active_conditions = []
+        template.current_room_id = None
+        return self.add_encounter_entry(state, template, weight)
+
+    def update_encounter_npc(
+        self,
+        state: GameState,
+        encounter_group_id: UUID,
+        npc_id: UUID,
+        name: str,
+        description: str,
+        hp_max: int,
+        defense: int,
+        notes: str = "",
+        hit_dice: int = 1,
+        resistance: int = 0,
+        weapon_range: int = 0,
+        damage_dice: str = "1d6",
+    ):
+        """Update an NPC inside an encounter roster template group."""
+        if state.dungeon is None:
+            return _err(state, "No dungeon loaded.")
+        for entry in state.dungeon.random_encounter_roster:
+            if entry.npc_group.group_id == encounter_group_id:
+                for npc in entry.npc_group.npcs:
+                    if npc.npc_id == npc_id:
+                        name_result = validate_non_empty_string(name, "NPC name", max_length=50)
+                        if not name_result:
+                            return _err(state, name_result.error)
+                        hp_result = validate_hp_value(hp_max)
+                        if not hp_result:
+                            return _err(state, hp_result.error)
+                        npc.name = name_result.value
+                        npc.description = description[:500]
+                        npc.hp_max = hp_result.value
+                        npc.hp_current = hp_result.value
+                        npc.defense = max(0, int(defense))
+                        npc.notes = notes[:500]
+                        npc.hit_dice = max(1, int(hit_dice))
+                        npc.resistance = max(0, int(resistance))
+                        npc.weapon_range = max(0, int(weapon_range))
+                        if damage_dice and damage_dice.strip():
+                            npc.damage_dice = damage_dice.strip()
+                        state.updated_at = _now()
+                        return _ok(state, f"{npc.name} updated.")
+                return _err(state, "NPC not found in encounter group.")
+        return _err(state, "Encounter entry not found.")
+
+    def remove_encounter_npc(self, state: GameState, encounter_group_id: UUID, npc_id: UUID):
+        """Remove an NPC from an encounter roster template group."""
+        if state.dungeon is None:
+            return _err(state, "No dungeon loaded.")
+        for entry in state.dungeon.random_encounter_roster:
+            if entry.npc_group.group_id == encounter_group_id:
+                success = entry.npc_group.remove_npc(npc_id)
+                if not success:
+                    return _err(state, "NPC not found in encounter group.")
+                state.updated_at = _now()
+                return _ok(state, "NPC removed from encounter template.")
+        return _err(state, "Encounter entry not found.")
+
+    def add_npc_to_encounter_group(self, state: GameState, encounter_group_id: UUID, npc: NPC):
+        """Add an NPC to an encounter roster template group."""
+        if state.dungeon is None:
+            return _err(state, "No dungeon loaded.")
+        for entry in state.dungeon.random_encounter_roster:
+            if entry.npc_group.group_id == encounter_group_id:
+                entry.npc_group.npcs.append(npc)
+                state.updated_at = _now()
+                return _ok(state, fmt_string("npc.appears", name=npc.name))
+        return _err(state, "Encounter entry not found.")

--- a/engine/npc.py
+++ b/engine/npc.py
@@ -133,6 +133,18 @@ class NPCManager:
         label = "hidden" if hidden else "visible"
         return _ok(state, f"{npc.name} is now {label}.")
 
+    def remove_npc_condition(self, state: GameState, npc_id, condition_id: str):
+        """Remove all instances of a named condition from an NPC."""
+        npc = _find_npc_in_roster(state, npc_id)
+        if npc is None:
+            return _err(state, fmt_string("npc.errors.not_found", npc_id=npc_id))
+        before = len(npc.active_conditions)
+        npc.active_conditions = [c for c in npc.active_conditions if c.condition_id != condition_id]
+        if len(npc.active_conditions) == before:
+            return _err(state, f"Condition '{condition_id}' not active on {npc.name}.")
+        state.updated_at = _now()
+        return _ok(state, f"Removed '{condition_id}' from {npc.name}.")
+
     def remove_npc_group(self, state: GameState, group_id):
         """Remove an NPC group from the roster."""
         success = state.npc_roster.remove_group(group_id)

--- a/models.py
+++ b/models.py
@@ -731,6 +731,7 @@ class CombatBattlefield:
     combatants:        dict[UUID, CombatantState] = field(default_factory=dict)
     round_log:         list[str]                  = field(default_factory=list)
     abscond_succeeded: bool                       = False
+    defeated_npc_log:  list[tuple[str, int]]      = field(default_factory=list)
 
 
 @dataclass

--- a/serialization.py
+++ b/serialization.py
@@ -290,6 +290,7 @@ def serialize_battlefield(bf: CombatBattlefield) -> dict:
             for cid, cs in bf.combatants.items()
         },
         "round_log": list(bf.round_log),
+        "defeated_npc_log": list(bf.defeated_npc_log),
     }
 
 
@@ -587,6 +588,7 @@ def deserialize_battlefield(d: dict) -> CombatBattlefield:
             for cid, cs in d.get("combatants", {}).items()
         },
         round_log=list(d.get("round_log", [])),
+        defeated_npc_log=[tuple(e) for e in d.get("defeated_npc_log", [])],
     )
 
 

--- a/serialization.py
+++ b/serialization.py
@@ -411,8 +411,11 @@ def deserialize_character(d: dict) -> Character:
         jobs = {k: deserialize_job_experience(v) for k, v in d["jobs"].items()}
     else:
         # Migrate: reconstruct a single JobExperience from the old character_class field.
-        old_val  = d.get("character_class", "Knight")
-        job_key  = CharacterClass(old_val).name.lower()
+        old_val = d.get("character_class", "Knight")
+        try:
+            job_key = CharacterClass(old_val).name.lower()
+        except ValueError:
+            job_key = next(iter(CharacterClass)).name.lower()
         jobs = {job_key: JobExperience(job_id=job_key, level=d.get("level", 1))}
 
     return Character(

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -299,7 +299,9 @@ class TestAutoResolveRound:
         auto_resolve_round(state)
         npc = state.npcs_in_current_room[0]
         assert npc.status == "dead"
-        assert npc_id not in state.battlefield.combatants
+        # Victory auto-exits combat when the last NPC falls
+        assert state.battlefield is None
+        assert state.mode == SessionMode.EXPLORATION
 
     def test_move_action_changes_range_band(self):
         state, char_id, npc_id = self._setup_combat()
@@ -333,7 +335,7 @@ class TestAutoResolveRound:
         assert len(result.message) > 0
 
     def test_round_log_stored_on_battlefield(self):
-        state, char_id, npc_id = self._setup_combat(npc_def=0)
+        state, char_id, npc_id = self._setup_combat(npc_hp=100, npc_def=0)
         state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
         state.battlefield.combatants[npc_id].range_band  = RangeBand.ENGAGE
 
@@ -410,11 +412,14 @@ class TestAutoResolveRound:
         result = auto_resolve_round(state)
         assert result.ok
 
-        log_text = "\n".join(state.battlefield.round_log)
+        # After victory, battlefield is cleared; check the full narrative instead
+        log_text = result.message
         # NPC should be defeated exactly once
         assert log_text.count("has been defeated") == 1
-        # XP awarded exactly once
-        assert log_text.count("XP") == 1
+        # XP awarded exactly once (not doubled), verified via character state
+        alice = state.characters[alice_id]
+        bob   = state.characters[bob_id]
+        assert alice.experience + bob.experience == 100  # hit_dice=1 → 100 XP total
         # Bob's wasted attack logged
         assert "already defeated" in log_text
 
@@ -833,6 +838,9 @@ class TestCombatSerialization:
 
     def test_battlefield_survives_round_trip(self):
         state = _make_state_with_npc()
+        # Use high HP so the NPC won't die (victory would clear the battlefield)
+        state.npcs_in_current_room[0].hp_current = 100
+        state.npcs_in_current_room[0].hp_max = 100
         enter_rounds(state)
         open_turn(state)
 
@@ -2801,3 +2809,185 @@ class TestHeavyTag:
         char.ability_scores.finesse = POWER_LEVEL * 5
         char.equipped_slots[ItemSlot.MAIN_HAND.value] = _find_heavy_weapon_id()
         assert _effective_finesse(state, char.character_id) == POWER_LEVEL
+
+
+# ---------------------------------------------------------------------------
+# Post-battle victory screen (Issue #39)
+# ---------------------------------------------------------------------------
+
+class TestVictoryScreen:
+    """XP is deferred until the last NPC dies; victory screen auto-exits combat."""
+
+    def _make_combat_state_one_npc(self, npc_hp=1, npc_def=0, npc_hit_dice=1):
+        from engine import add_npc, register_room
+        from models import Room
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Hero", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        start_session(state)
+        room = Room(name="Hall", description="Stone hall.")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        char = list(state.characters.values())[0]
+        char.hp_current = char.hp_max = 100
+        npc = NPC(name="Goblin", hp_current=npc_hp, hp_max=npc_hp,
+                  defense=npc_def, damage_dice="1d6", hit_dice=npc_hit_dice)
+        add_npc(state, npc)
+        enter_rounds(state)
+        open_turn(state)
+        char_id = list(state.characters.keys())[0]
+        return state, char_id, npc.npc_id
+
+    def _make_combat_state_two_npcs(self):
+        """One character, Kobold (1 HP, hit_dice=1) + Orc (100 HP, hit_dice=2)."""
+        from engine import add_npc, register_room
+        from models import Room
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Hero", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        start_session(state)
+        room = Room(name="Hall", description="Stone hall.")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        char = list(state.characters.values())[0]
+        char.hp_current = char.hp_max = 100
+        kobold = NPC(name="Kobold", hp_current=1, hp_max=1, defense=0, damage_dice="1d4", hit_dice=1)
+        orc    = NPC(name="Orc",    hp_current=100, hp_max=100, defense=0, damage_dice="1d4", hit_dice=2)
+        add_npc(state, kobold)
+        add_npc(state, orc)
+        enter_rounds(state)
+        open_turn(state)
+        char_id = list(state.characters.keys())[0]
+        return state, char_id, kobold.npc_id, orc.npc_id
+
+    def _submit_attack(self, state, char_id, target_id):
+        from models import PlayerTurnSubmission
+        state.battlefield.combatants[char_id].range_band   = RangeBand.ENGAGE
+        state.battlefield.combatants[target_id].range_band = RangeBand.ENGAGE
+        action = CombatAction(action_id="attack", target_id=target_id)
+        state.current_turn.submissions = [PlayerTurnSubmission(
+            character_id=char_id, action_text="Attack",
+            is_latest=True, combat_action=action.to_dict(),
+        )]
+
+    def test_xp_not_distributed_mid_combat(self):
+        """Killing one NPC while another survives defers XP and stays in ROUNDS."""
+        state, char_id, kobold_id, orc_id = self._make_combat_state_two_npcs()
+        state.battlefield.combatants[char_id].initiative  = 100
+        self._submit_attack(state, char_id, kobold_id)
+
+        auto_resolve_round(state)
+
+        char = state.characters[char_id]
+        assert char.experience == 0
+        assert state.mode == SessionMode.ROUNDS
+        assert state.battlefield is not None
+        assert len(state.battlefield.defeated_npc_log) == 1
+        assert state.battlefield.defeated_npc_log[0] == ("Kobold", 100)
+
+    def test_xp_distributed_on_last_npc_death(self):
+        """When the last NPC dies, XP is awarded and combat exits to EXPLORATION."""
+        state, char_id, npc_id = self._make_combat_state_one_npc(npc_hp=1, npc_hit_dice=2)
+        self._submit_attack(state, char_id, npc_id)
+
+        auto_resolve_round(state)
+
+        assert state.mode == SessionMode.EXPLORATION
+        assert state.battlefield is None
+        char = state.characters[char_id]
+        assert char.experience == 200  # hit_dice=2 → 200 XP
+
+    def test_victory_narrative_contains_header_and_npc_row(self):
+        """Victory screen with NPC name and XP value appears in the narrative."""
+        state, char_id, npc_id = self._make_combat_state_one_npc(npc_hp=1, npc_hit_dice=1)
+        self._submit_attack(state, char_id, npc_id)
+
+        result = auto_resolve_round(state)
+
+        assert "Victory" in result.message
+        assert "Goblin" in result.message
+        assert "XP" in result.message
+
+    def test_victory_xp_split_among_active_party(self):
+        """With two characters, XP from one NPC is split evenly."""
+        from engine import add_npc, register_room
+        from models import Room
+        state = GameState(platform_channel_id="ch", dm_user_id="dm")
+        state.party = Party(name="P")
+        create_character(state, "Alice", CharacterClass.KNIGHT, "Pack A", owner_id="u1")
+        create_character(state, "Bob",   CharacterClass.KNIGHT, "Pack A", owner_id="u2")
+        start_session(state)
+        room = Room(name="Hall", description="Stone hall.")
+        register_room(state, room)
+        state.current_room_id = room.room_id
+        for char in state.characters.values():
+            char.hp_current = char.hp_max = 100
+        npc = NPC(name="Ogre", hp_current=1, hp_max=1, defense=0, damage_dice="1d4", hit_dice=2)
+        add_npc(state, npc)
+        enter_rounds(state)
+        open_turn(state)
+        char_ids = list(state.characters.keys())
+        alice_id, bob_id = char_ids[0], char_ids[1]
+        state.battlefield.combatants[alice_id].initiative   = 100
+        state.battlefield.combatants[alice_id].range_band   = RangeBand.ENGAGE
+        state.battlefield.combatants[bob_id].range_band     = RangeBand.ENGAGE
+        state.battlefield.combatants[npc.npc_id].range_band = RangeBand.ENGAGE
+        from models import PlayerTurnSubmission
+        state.current_turn.submissions = [
+            PlayerTurnSubmission(
+                character_id=alice_id, action_text="Attack", is_latest=True,
+                combat_action=CombatAction(action_id="attack", target_id=npc.npc_id).to_dict(),
+            ),
+            PlayerTurnSubmission(
+                character_id=bob_id, action_text="Attack", is_latest=True,
+                combat_action=CombatAction(action_id="attack", target_id=npc.npc_id).to_dict(),
+            ),
+        ]
+
+        auto_resolve_round(state)
+
+        # hit_dice=2 → 200 XP total; 100 each for two active characters
+        for char in state.characters.values():
+            assert char.experience == 100
+
+    def test_no_victory_while_npc_remains(self):
+        """Combat does not exit while any NPC combatant is still alive."""
+        state, char_id, kobold_id, orc_id = self._make_combat_state_two_npcs()
+        state.battlefield.combatants[char_id].initiative = 100
+        self._submit_attack(state, char_id, kobold_id)
+
+        auto_resolve_round(state)
+
+        assert state.mode == SessionMode.ROUNDS
+        assert state.battlefield is not None
+        assert state.characters[char_id].experience == 0
+
+    def test_battlefield_serialization_preserves_defeated_npc_log(self):
+        """defeated_npc_log survives a serialize/deserialize round-trip."""
+        state, char_id, npc_id = self._make_combat_state_one_npc()
+        state.battlefield.defeated_npc_log.append(("Goblin", 100))
+        state.battlefield.defeated_npc_log.append(("Orc", 200))
+
+        d = serialize_state(state)
+        restored = deserialize_state(d)
+
+        assert restored.battlefield.defeated_npc_log == [("Goblin", 100), ("Orc", 200)]
+
+    def test_abscond_does_not_trigger_victory_block(self):
+        """When abscond succeeds, the victory XP block is skipped."""
+        state, char_id, npc_id = self._make_combat_state_one_npc(npc_hp=100, npc_hit_dice=2)
+        # Simulate a prior kill recorded in the log
+        state.battlefield.defeated_npc_log.append(("Minion", 100))
+        state.battlefield.abscond_succeeded = True
+        from models import PlayerTurnSubmission
+        state.current_turn.submissions = [PlayerTurnSubmission(
+            character_id=char_id, action_text="Move", is_latest=True,
+            combat_action=CombatAction(action_id="move",
+                                       destination=RangeBand.FAR_MINUS).to_dict(),
+        )]
+
+        auto_resolve_round(state)
+
+        assert state.mode == SessionMode.EXPLORATION
+        assert state.battlefield is None
+        assert state.characters[char_id].experience == 0

--- a/tests/test_combat_engine.py
+++ b/tests/test_combat_engine.py
@@ -2991,3 +2991,130 @@ class TestVictoryScreen:
         assert state.mode == SessionMode.EXPLORATION
         assert state.battlefield is None
         assert state.characters[char_id].experience == 0
+
+
+# ---------------------------------------------------------------------------
+# Asleep condition + remove_this_condition_on_roll hook
+# ---------------------------------------------------------------------------
+
+class TestAsleepCondition:
+    """
+    Tests for the asleep condition and the general-purpose
+    remove_this_condition_on_roll hook it uses at on_turn_end.
+    """
+
+    def _state_in_rounds(self):
+        state = _make_state_with_npc()
+        enter_rounds(state)
+        char_id = list(state.characters.keys())[0]
+        npc = state.npcs_in_current_room[0]
+        state.battlefield.combatants[char_id].range_band = RangeBand.ENGAGE
+        state.battlefield.combatants[npc.npc_id].range_band = RangeBand.ENGAGE
+        state.characters[char_id].hp_current = 20
+        state.characters[char_id].hp_max = 20
+        npc.hp_current = 20
+        npc.hp_max = 20
+        return state, char_id, npc
+
+    def test_asleep_in_registry(self):
+        from engine import CONDITION_REGISTRY
+        assert "asleep" in CONDITION_REGISTRY
+        cond = CONDITION_REGISTRY["asleep"]
+        assert cond.hooks.get("on_turn_start") == "skip_action"
+        hook = cond.hooks.get("on_turn_end")
+        assert isinstance(hook, dict)
+        assert hook["tag"] == "remove_this_condition_on_roll"
+        assert hook["dice"] == "1d4"
+        assert hook["threshold"] == 4
+
+    def test_hook_is_registered(self):
+        from engine.combat_hooks import _HOOK_DISPATCH
+        assert "remove_this_condition_on_roll" in _HOOK_DISPATCH
+
+    def test_removed_on_threshold_roll(self):
+        from unittest.mock import patch
+
+        from engine.combat_hooks import _tick_actor_conditions
+        state, char_id, _ = self._state_in_rounds()
+        apply_condition(state, char_id, "asleep", duration=3)
+
+        log: list[str] = []
+        with patch("engine.combat_hooks.roll_dice_expr", return_value={"total": 4}):
+            _tick_actor_conditions(state, char_id, log)
+
+        char = state.characters[char_id]
+        assert not any(c.condition_id == "asleep" for c in char.active_conditions)
+        assert any("Asleep" in e or "asleep" in e for e in log)
+
+    def test_persists_on_low_roll(self):
+        from unittest.mock import patch
+
+        from engine.combat_hooks import _tick_actor_conditions
+        state, char_id, _ = self._state_in_rounds()
+        apply_condition(state, char_id, "asleep", duration=3)
+
+        log: list[str] = []
+        with patch("engine.combat_hooks.roll_dice_expr", return_value={"total": 3}):
+            _tick_actor_conditions(state, char_id, log)
+
+        char = state.characters[char_id]
+        assert any(c.condition_id == "asleep" for c in char.active_conditions)
+
+    def test_skip_action_fires_while_asleep(self):
+        from engine.combat import _fire_turn_start_hooks
+        state, char_id, _ = self._state_in_rounds()
+        apply_condition(state, char_id, "asleep", duration=2)
+
+        log: list[str] = []
+        _fire_turn_start_hooks(state, log)
+
+        cs = state.battlefield.combatants[char_id]
+        assert cs.skip_action is True
+
+    def test_expires_by_duration_when_rolls_always_fail(self):
+        from unittest.mock import patch
+
+        from engine.combat_hooks import _tick_actor_conditions
+        state, char_id, _ = self._state_in_rounds()
+        apply_condition(state, char_id, "asleep", duration=2)
+
+        with patch("engine.combat_hooks.roll_dice_expr", return_value={"total": 1}):
+            _tick_actor_conditions(state, char_id, [])  # duration 2→1
+            _tick_actor_conditions(state, char_id, [])  # duration 1 → expired
+
+        char = state.characters[char_id]
+        assert not any(c.condition_id == "asleep" for c in char.active_conditions)
+
+    def test_no_expiry_log_when_removed_by_roll(self):
+        from unittest.mock import patch
+
+        from engine.combat_hooks import _tick_actor_conditions
+        state, char_id, _ = self._state_in_rounds()
+        apply_condition(state, char_id, "asleep", duration=3)
+
+        log: list[str] = []
+        with patch("engine.combat_hooks.roll_dice_expr", return_value={"total": 4}):
+            _tick_actor_conditions(state, char_id, log)
+
+        assert not any("expired" in e.lower() for e in log)
+
+    def test_works_on_npc(self):
+        from unittest.mock import patch
+
+        from engine.combat_hooks import _tick_actor_conditions
+        state, _, npc = self._state_in_rounds()
+        apply_condition(state, npc.npc_id, "asleep", duration=3)
+
+        log: list[str] = []
+        with patch("engine.combat_hooks.roll_dice_expr", return_value={"total": 4}):
+            _tick_actor_conditions(state, npc.npc_id, log)
+
+        assert not any(c.condition_id == "asleep" for c in npc.active_conditions)
+
+    def test_missing_condition_id_logs_warning(self):
+        from engine.combat_hooks import _HOOK_DISPATCH
+        state, char_id, _ = self._state_in_rounds()
+        log: list[str] = []
+        handler = _HOOK_DISPATCH["remove_this_condition_on_roll"]
+        handler(state, char_id, None, log, {"dice": "1d4", "threshold": 4})
+        assert any("_condition_id" in e or "not injected" in e for e in log)

--- a/tests/test_dungeon.py
+++ b/tests/test_dungeon.py
@@ -552,6 +552,22 @@ class TestLightSources:
         inv2 = next(i for i in char.inventory if i.item_id == "lantern" and i.equipped)
         assert inv2.charges == 0  # no oil → still dark
 
+    def test_lantern_equipped_before_oil_lights_on_first_tick(self, state_with_fighter):
+        """Lantern equipped dark (no oil at equip time) auto-lights when oil is acquired and the first turn resolves."""
+        from engine import equip_item, give_item, resolve_turn, start_session
+        from engine.azure_constants import ItemSlot
+        char = next(iter(state_with_fighter.characters.values()))
+        give_item(state_with_fighter, char.character_id, "lantern", 1)
+        equip_item(state_with_fighter, char.character_id, "lantern", ItemSlot.OFF_HAND)
+        inv = next(i for i in char.inventory if i.item_id == "lantern" and i.equipped)
+        assert inv.charges == 0  # dark: no oil at equip time
+        give_item(state_with_fighter, char.character_id, "oil_flask", 1)
+        start_session(state_with_fighter)
+        resolve_turn(state_with_fighter, "The party moves forward.")
+        # After the first tick the dark lantern should have consumed the oil and lit
+        assert inv.charges == 24
+        assert all(i.item_id != "oil_flask" for i in char.inventory)
+
     def test_light_does_not_tick_in_combat(self, active_state):
         char = next(iter(active_state.characters.values()))
         from engine import equip_item, give_item

--- a/tests/test_npc_roster.py
+++ b/tests/test_npc_roster.py
@@ -1,0 +1,308 @@
+"""
+tests/test_npc_roster.py — Tests for NPC roster management and encounter roster engine methods.
+
+Covers:
+  - add_npc_to_group: adds NPC to correct group, error on bad group_id
+  - update_group: name, movement_logic, current_room_id, possible_rooms all update
+  - add_encounter_entry: appends to roster, error when no dungeon
+  - remove_encounter_entry: removes by group_id, error on not found
+  - update_encounter_entry_weight: updates weight correctly
+  - promote_group_to_encounter: copy is independent; live group still exists; current_room_id cleared
+  - update_encounter_npc / remove_encounter_npc / add_npc_to_encounter_group
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from uuid import uuid4
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from engine import (
+    add_encounter_entry,
+    add_npc_to_encounter_group,
+    add_npc_to_group,
+    promote_group_to_encounter,
+    remove_encounter_entry,
+    remove_encounter_npc,
+    update_encounter_entry_weight,
+    update_encounter_npc,
+    update_group,
+)
+from models import (
+    NPC,
+    Dungeon,
+    GameState,
+    NPCGroup,
+    NPCMovementLogic,
+    Party,
+    Room,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_state_with_dungeon() -> tuple[GameState, Room, Room]:
+    """State with a minimal dungeon (two rooms) and an NPC group in room1."""
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    state.party = Party(name="P")
+
+    room1 = Room(name="Hall")
+    room2 = Room(name="Vault")
+    dungeon = Dungeon(name="Test Dungeon")
+    dungeon.rooms[room1.room_id] = room1
+    dungeon.rooms[room2.room_id] = room2
+    state.dungeon = dungeon
+
+    npc = NPC(name="Goblin A", hp_max=10, hp_current=10, defense=1)
+    group = NPCGroup(name="Goblins", npcs=[npc], current_room_id=room1.room_id)
+    state.npc_roster.add_group(group)
+
+    return state, room1, room2
+
+
+def _get_only_group(state: GameState) -> NPCGroup:
+    return next(iter(state.npc_roster.groups.values()))
+
+
+# ---------------------------------------------------------------------------
+# add_npc_to_group
+# ---------------------------------------------------------------------------
+
+def test_add_npc_to_group_success():
+    state, room1, _ = _make_state_with_dungeon()
+    group = _get_only_group(state)
+    new_npc = NPC(name="Goblin B", hp_max=8, hp_current=8)
+
+    result = add_npc_to_group(state, group.group_id, new_npc)
+
+    assert result.ok
+    assert len(group.npcs) == 2
+    assert group.npcs[1].name == "Goblin B"
+
+
+def test_add_npc_to_group_bad_id():
+    state, _, _ = _make_state_with_dungeon()
+    fake_id = uuid4()
+    npc = NPC(name="Ghost", hp_max=5, hp_current=5)
+
+    result = add_npc_to_group(state, fake_id, npc)
+
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# update_group
+# ---------------------------------------------------------------------------
+
+def test_update_group_name_and_logic():
+    state, room1, room2 = _make_state_with_dungeon()
+    group = _get_only_group(state)
+
+    result = update_group(
+        state, group.group_id,
+        name="Wandering Goblins",
+        movement_logic=NPCMovementLogic.WANDERING,
+        current_room_id=room2.room_id,
+        possible_rooms=[room1.room_id, room2.room_id],
+    )
+
+    assert result.ok
+    assert group.name == "Wandering Goblins"
+    assert group.movement_logic == NPCMovementLogic.WANDERING
+    assert group.current_room_id == room2.room_id
+    assert room1.room_id in group.possible_rooms
+    assert room2.room_id in group.possible_rooms
+
+
+def test_update_group_clear_name():
+    state, room1, _ = _make_state_with_dungeon()
+    group = _get_only_group(state)
+
+    result = update_group(
+        state, group.group_id,
+        name="",
+        movement_logic=NPCMovementLogic.STATIONARY,
+        current_room_id=room1.room_id,
+        possible_rooms=[],
+    )
+
+    assert result.ok
+    assert group.name is None
+
+
+def test_update_group_bad_id():
+    state, _, _ = _make_state_with_dungeon()
+    result = update_group(state, uuid4(), "", NPCMovementLogic.STATIONARY, None, [])
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# add_encounter_entry
+# ---------------------------------------------------------------------------
+
+def test_add_encounter_entry():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(name="Skeletons", npcs=[NPC(name="Sk A", hp_max=6, hp_current=6)])
+
+    result = add_encounter_entry(state, template, weight=3)
+
+    assert result.ok
+    assert len(state.dungeon.random_encounter_roster) == 1
+    assert state.dungeon.random_encounter_roster[0].weight == 3
+    assert state.dungeon.random_encounter_roster[0].npc_group.name == "Skeletons"
+
+
+def test_add_encounter_entry_no_dungeon():
+    state = GameState(platform_channel_id="ch", dm_user_id="dm")
+    template = NPCGroup(name="X", npcs=[NPC(name="X", hp_max=5, hp_current=5)])
+
+    result = add_encounter_entry(state, template, weight=1)
+
+    assert not result.ok
+
+
+def test_add_encounter_entry_weight_minimum():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(npcs=[NPC(name="Rat", hp_max=2, hp_current=2)])
+
+    add_encounter_entry(state, template, weight=0)
+
+    assert state.dungeon.random_encounter_roster[0].weight == 1
+
+
+# ---------------------------------------------------------------------------
+# remove_encounter_entry
+# ---------------------------------------------------------------------------
+
+def test_remove_encounter_entry():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(npcs=[NPC(name="Orc", hp_max=12, hp_current=12)])
+    add_encounter_entry(state, template, weight=2)
+    entry_group_id = state.dungeon.random_encounter_roster[0].npc_group.group_id
+
+    result = remove_encounter_entry(state, entry_group_id)
+
+    assert result.ok
+    assert len(state.dungeon.random_encounter_roster) == 0
+
+
+def test_remove_encounter_entry_not_found():
+    state, _, _ = _make_state_with_dungeon()
+    result = remove_encounter_entry(state, uuid4())
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# update_encounter_entry_weight
+# ---------------------------------------------------------------------------
+
+def test_update_encounter_entry_weight():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(npcs=[NPC(name="Troll", hp_max=30, hp_current=30)])
+    add_encounter_entry(state, template, weight=1)
+    group_id = state.dungeon.random_encounter_roster[0].npc_group.group_id
+
+    result = update_encounter_entry_weight(state, group_id, 5)
+
+    assert result.ok
+    assert state.dungeon.random_encounter_roster[0].weight == 5
+
+
+def test_update_encounter_entry_weight_not_found():
+    state, _, _ = _make_state_with_dungeon()
+    result = update_encounter_entry_weight(state, uuid4(), 3)
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# promote_group_to_encounter
+# ---------------------------------------------------------------------------
+
+def test_promote_group_to_encounter_copy_is_independent():
+    state, room1, _ = _make_state_with_dungeon()
+    live_group = _get_only_group(state)
+    original_group_id = live_group.group_id
+    original_npc_id = live_group.npcs[0].npc_id
+
+    result = promote_group_to_encounter(state, live_group.group_id, weight=2)
+
+    assert result.ok
+    # Live group still exists
+    assert original_group_id in state.npc_roster.groups
+
+    entry = state.dungeon.random_encounter_roster[0]
+    # Template is a different object with different IDs
+    assert entry.npc_group.group_id != original_group_id
+    assert entry.npc_group.npcs[0].npc_id != original_npc_id
+    assert entry.weight == 2
+
+
+def test_promote_group_to_encounter_clears_room():
+    state, room1, _ = _make_state_with_dungeon()
+    live_group = _get_only_group(state)
+    assert live_group.current_room_id == room1.room_id
+
+    promote_group_to_encounter(state, live_group.group_id, weight=1)
+
+    entry = state.dungeon.random_encounter_roster[0]
+    # Template has no room assignment
+    assert entry.npc_group.current_room_id is None
+
+
+def test_promote_group_to_encounter_bad_id():
+    state, _, _ = _make_state_with_dungeon()
+    result = promote_group_to_encounter(state, uuid4(), weight=1)
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# update_encounter_npc / remove_encounter_npc / add_npc_to_encounter_group
+# ---------------------------------------------------------------------------
+
+def test_update_encounter_npc():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(name="Orcs", npcs=[NPC(name="Orc A", hp_max=15, hp_current=15)])
+    add_encounter_entry(state, template, weight=1)
+    entry = state.dungeon.random_encounter_roster[0]
+    eg_id = entry.npc_group.group_id
+    npc_id = entry.npc_group.npcs[0].npc_id
+
+    result = update_encounter_npc(state, eg_id, npc_id, "Orc Chief", "", 25, 3)
+
+    assert result.ok
+    npc = entry.npc_group.npcs[0]
+    assert npc.name == "Orc Chief"
+    assert npc.hp_max == 25
+    assert npc.defense == 3
+
+
+def test_remove_encounter_npc():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(npcs=[NPC(name="Bat", hp_max=3, hp_current=3)])
+    add_encounter_entry(state, template, weight=1)
+    entry = state.dungeon.random_encounter_roster[0]
+    eg_id = entry.npc_group.group_id
+    npc_id = entry.npc_group.npcs[0].npc_id
+
+    result = remove_encounter_npc(state, eg_id, npc_id)
+
+    assert result.ok
+    assert len(entry.npc_group.npcs) == 0
+
+
+def test_add_npc_to_encounter_group():
+    state, _, _ = _make_state_with_dungeon()
+    template = NPCGroup(name="Pack", npcs=[NPC(name="Wolf A", hp_max=8, hp_current=8)])
+    add_encounter_entry(state, template, weight=1)
+    entry = state.dungeon.random_encounter_roster[0]
+    eg_id = entry.npc_group.group_id
+    new_npc = NPC(name="Wolf B", hp_max=8, hp_current=8)
+
+    result = add_npc_to_encounter_group(state, eg_id, new_npc)
+
+    assert result.ok
+    assert len(entry.npc_group.npcs) == 2
+    assert entry.npc_group.npcs[1].name == "Wolf B"

--- a/webui/app.py
+++ b/webui/app.py
@@ -23,6 +23,9 @@ from fastapi.responses import HTMLResponse, Response
 import store
 from discord_tasks import dispatch_oracle_answer, dispatch_turn_resolved, drain_level_ups
 from engine import (
+    add_encounter_entry as eng_add_encounter_entry,
+)
+from engine import (
     add_exit,
     adjust_light_charges,
     adjust_skill_uses,
@@ -66,12 +69,41 @@ from engine import (
     add_npc as eng_add_npc,
 )
 from engine import (
+    add_npc_to_encounter_group as eng_add_npc_to_encounter_group,
+)
+from engine import (
+    add_npc_to_group as eng_add_npc_to_group,
+)
+from engine import (
     copy_npc as eng_copy_npc,
+)
+from engine import (
+    promote_group_to_encounter as eng_promote_group,
+)
+from engine import (
+    remove_encounter_entry as eng_remove_encounter_entry,
+)
+from engine import (
+    remove_encounter_npc as eng_remove_encounter_npc,
+)
+from engine import (
+    remove_npc_group_by_id as eng_remove_npc_group,
+)
+from engine import (
+    update_encounter_entry_weight as eng_update_encounter_weight,
+)
+from engine import (
+    update_encounter_npc as eng_update_encounter_npc,
+)
+from engine import (
+    update_group as eng_update_group,
 )
 from models import (
     NPC,
     CharacterStatus,
     DoorState,
+    NPCGroup,
+    NPCMovementLogic,
     RangeBand,
     Room,
     RoomFeature,
@@ -82,6 +114,8 @@ from webui.templates import (
     archive_page,
     character_page,
     dashboard_fragment,
+    npc_roster_fragment,
+    npc_roster_page,
     session_list_page,
     session_page,
 )
@@ -161,6 +195,19 @@ def _respond(channel_id: str, flash: str = "", error: str = "", sync: bool = Tru
         tb = traceback.format_exc()
         print(f"[_respond] dashboard_fragment error: {exc}\n{tb}", file=sys.stderr)
         return HTMLResponse(f'<div id="dashboard"><div class="error">Render error: {exc}</div></div>')
+
+
+def _respond_npcs(channel_id: str, flash: str = "", error: str = "", edit_id: str = "") -> HTMLResponse:
+    import traceback
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse('<div class="error">Session not found.</div>')
+    try:
+        return HTMLResponse(npc_roster_fragment(state, flash=flash, error=error, edit_id=edit_id))
+    except Exception as exc:
+        tb = traceback.format_exc()
+        print(f"[_respond_npcs] npc_roster_fragment error: {exc}\n{tb}", file=sys.stderr)
+        return HTMLResponse(f'<div id="npc-roster"><div class="error">Render error: {exc}</div></div>')
 
 
 # ---------------------------------------------------------------------------
@@ -750,14 +797,19 @@ async def route_dungeon_update(
     random_encounter_interval: Annotated[int, Form()] = 6,
     random_encounter_roll: Annotated[str, Form()] = "1d6",
     view_room_id: Annotated[str, Form()] = "",
+    from_page: Annotated[str, Form()] = "",
 ):
     state = store.get_session(channel_id)
     if state is None:
         return HTMLResponse("Session not found.", status_code=404)
     result = update_dungeon(state, name, description, random_encounter_interval, random_encounter_roll)
     if not result.ok:
+        if from_page == "npcs":
+            return _respond_npcs(channel_id, error=result.error)
         return _respond(channel_id, error=result.error, view_room_id=view_room_id)
     await save_session_async(state)
+    if from_page == "npcs":
+        return _respond_npcs(channel_id, flash=result.message)
     return _respond(channel_id, flash=result.message, view_room_id=view_room_id)
 
 
@@ -950,6 +1002,7 @@ async def route_npc_update(
     weapon_range: Annotated[int, Form()] = 0,
     damage_dice: Annotated[str, Form()] = "1d6",
     view_room_id: Annotated[str, Form()] = "",
+    from_page: Annotated[str, Form()] = "",
 ):
     import traceback
     state = store.get_session(channel_id)
@@ -961,12 +1014,18 @@ async def route_npc_update(
             notes, hit_dice, resistance, weapon_range, damage_dice,
         )
         if not result.ok:
+            if from_page == "npcs":
+                return _respond_npcs(channel_id, error=result.error)
             return _respond(channel_id, error=result.error, view_room_id=view_room_id)
         await save_session_async(state)
+        if from_page == "npcs":
+            return _respond_npcs(channel_id, flash=result.message)
         return _respond(channel_id, flash=result.message, view_room_id=view_room_id)
     except Exception as exc:
         tb = traceback.format_exc()
         print(f"[route_npc_update] ERROR for npc_id={npc_id}: {exc}\n{tb}", file=sys.stderr)
+        if from_page == "npcs":
+            return _respond_npcs(channel_id, error=f"Server error: {exc}")
         return _respond(channel_id, error=f"Server error: {exc}", view_room_id=view_room_id)
 
 
@@ -975,14 +1034,19 @@ async def route_npc_delete(
     channel_id: str,
     npc_id: str,
     view_room_id: Annotated[str, Form()] = "",
+    from_page: Annotated[str, Form()] = "",
 ):
     state = store.get_session(channel_id)
     if state is None:
         return HTMLResponse("Session not found.", status_code=404)
     result = remove_npc(state, UUID(npc_id))
     if not result.ok:
+        if from_page == "npcs":
+            return _respond_npcs(channel_id, error=result.error)
         return _respond(channel_id, error=result.error, view_room_id=view_room_id)
     await save_session_async(state)
+    if from_page == "npcs":
+        return _respond_npcs(channel_id)
     return _respond(channel_id, view_room_id=view_room_id)
 
 
@@ -991,6 +1055,7 @@ async def route_npc_copy(
     channel_id: str,
     npc_id: str,
     view_room_id: Annotated[str, Form()] = "",
+    from_page: Annotated[str, Form()] = "",
 ):
     state = store.get_session(channel_id)
     if state is None:
@@ -998,10 +1063,276 @@ async def route_npc_copy(
     rid = _parse_uuid(view_room_id)
     result = eng_copy_npc(state, UUID(npc_id), room_id=rid)
     if not result.ok:
+        if from_page == "npcs":
+            return _respond_npcs(channel_id, error=result.error)
         return _respond(channel_id, error=result.error, view_room_id=view_room_id)
     await save_session_async(state)
+    if from_page == "npcs":
+        return _respond_npcs(channel_id)
     return _respond(channel_id, view_room_id=view_room_id)
 
+
+# ---------------------------------------------------------------------------
+# NPC Roster page
+# ---------------------------------------------------------------------------
+
+@app.get("/session/{channel_id}/npcs", response_class=HTMLResponse)
+async def route_npc_roster_page(channel_id: str, edit: str = ""):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    sessions = _session_list()
+    return HTMLResponse(npc_roster_page(state, sessions, edit_id=edit))
+
+
+@app.post("/session/{channel_id}/addgroup", response_class=HTMLResponse)
+async def route_addgroup(
+    channel_id: str,
+    name: Annotated[str, Form()],
+    hp: Annotated[int, Form()],
+    group_name: Annotated[str, Form()] = "",
+    movement_logic: Annotated[str, Form()] = "stationary",
+    defense: Annotated[int, Form()] = 0,
+    resistance: Annotated[int, Form()] = 0,
+    damage_dice: Annotated[str, Form()] = "1d6",
+    hit_dice: Annotated[int, Form()] = 1,
+    weapon_range: Annotated[int, Form()] = 0,
+    description: Annotated[str, Form()] = "",
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    try:
+        logic = NPCMovementLogic(movement_logic)
+    except ValueError:
+        logic = NPCMovementLogic.STATIONARY
+    npc = NPC(
+        name=name, hp_max=hp, hp_current=hp,
+        defense=defense, damage_dice=damage_dice,
+        hit_dice=hit_dice, resistance=resistance,
+        weapon_range=weapon_range, description=description,
+    )
+    group = NPCGroup(
+        name=group_name or None,
+        npcs=[npc],
+        movement_logic=logic,
+    )
+    from engine import add_npc_group as eng_add_group
+    result = eng_add_group(state, group)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message if result.ok else "", error="" if result.ok else result.error)
+
+
+@app.post("/session/{channel_id}/group/{group_id}/update", response_class=HTMLResponse)
+async def route_group_update(
+    request: Request,
+    channel_id: str,
+    group_id: str,
+    name: Annotated[str, Form()] = "",
+    movement_logic: Annotated[str, Form()] = "stationary",
+    current_room_id: Annotated[str, Form()] = "",
+):
+    form_data = await request.form()
+    possible_rooms = form_data.getlist("possible_rooms")
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    try:
+        logic = NPCMovementLogic(movement_logic)
+    except ValueError:
+        logic = NPCMovementLogic.STATIONARY
+    room_id = _parse_uuid(current_room_id)
+    possible = [UUID(r) for r in possible_rooms if r]
+    result = eng_update_group(state, UUID(group_id), name or None, logic, room_id, possible)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/group/{group_id}/delete", response_class=HTMLResponse)
+async def route_group_delete(channel_id: str, group_id: str):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    result = eng_remove_npc_group(state, UUID(group_id))
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/group/{group_id}/addnpc", response_class=HTMLResponse)
+async def route_group_addnpc(
+    channel_id: str,
+    group_id: str,
+    name: Annotated[str, Form()],
+    hp: Annotated[int, Form()],
+    defense: Annotated[int, Form()] = 0,
+    resistance: Annotated[int, Form()] = 0,
+    damage_dice: Annotated[str, Form()] = "1d6",
+    hit_dice: Annotated[int, Form()] = 1,
+    weapon_range: Annotated[int, Form()] = 0,
+    description: Annotated[str, Form()] = "",
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    npc = NPC(
+        name=name, hp_max=hp, hp_current=hp,
+        defense=defense, damage_dice=damage_dice,
+        hit_dice=hit_dice, resistance=resistance,
+        weapon_range=weapon_range, description=description,
+    )
+    result = eng_add_npc_to_group(state, UUID(group_id), npc)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/group/{group_id}/promote_encounter", response_class=HTMLResponse)
+async def route_group_promote_encounter(
+    channel_id: str,
+    group_id: str,
+    weight: Annotated[int, Form()] = 1,
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    result = eng_promote_group(state, UUID(group_id), weight)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/encounter_roster/add", response_class=HTMLResponse)
+async def route_encounter_roster_add(
+    channel_id: str,
+    name: Annotated[str, Form()],
+    hp: Annotated[int, Form()],
+    group_name: Annotated[str, Form()] = "",
+    weight: Annotated[int, Form()] = 1,
+    defense: Annotated[int, Form()] = 0,
+    resistance: Annotated[int, Form()] = 0,
+    damage_dice: Annotated[str, Form()] = "1d6",
+    hit_dice: Annotated[int, Form()] = 1,
+    weapon_range: Annotated[int, Form()] = 0,
+    description: Annotated[str, Form()] = "",
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    npc = NPC(
+        name=name, hp_max=hp, hp_current=hp,
+        defense=defense, damage_dice=damage_dice,
+        hit_dice=hit_dice, resistance=resistance,
+        weapon_range=weapon_range, description=description,
+    )
+    template_group = NPCGroup(name=group_name or None, npcs=[npc])
+    result = eng_add_encounter_entry(state, template_group, weight)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/encounter_roster/{group_id}/update_weight", response_class=HTMLResponse)
+async def route_encounter_weight(
+    channel_id: str,
+    group_id: str,
+    weight: Annotated[int, Form()] = 1,
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    result = eng_update_encounter_weight(state, UUID(group_id), weight)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/encounter_roster/{group_id}/delete", response_class=HTMLResponse)
+async def route_encounter_delete(channel_id: str, group_id: str):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    result = eng_remove_encounter_entry(state, UUID(group_id))
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/encounter_roster/{group_id}/addnpc", response_class=HTMLResponse)
+async def route_encounter_addnpc(
+    channel_id: str,
+    group_id: str,
+    name: Annotated[str, Form()],
+    hp: Annotated[int, Form()],
+    defense: Annotated[int, Form()] = 0,
+    resistance: Annotated[int, Form()] = 0,
+    damage_dice: Annotated[str, Form()] = "1d6",
+    hit_dice: Annotated[int, Form()] = 1,
+    weapon_range: Annotated[int, Form()] = 0,
+    description: Annotated[str, Form()] = "",
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    npc = NPC(
+        name=name, hp_max=hp, hp_current=hp,
+        defense=defense, damage_dice=damage_dice,
+        hit_dice=hit_dice, resistance=resistance,
+        weapon_range=weapon_range, description=description,
+    )
+    result = eng_add_npc_to_encounter_group(state, UUID(group_id), npc)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/encounter_roster/{group_id}/npc/{npc_id}/update", response_class=HTMLResponse)
+async def route_encounter_npc_update(
+    channel_id: str,
+    group_id: str,
+    npc_id: str,
+    name: Annotated[str, Form()],
+    hp_max: Annotated[int, Form()],
+    defense: Annotated[int, Form()] = 0,
+    resistance: Annotated[int, Form()] = 0,
+    damage_dice: Annotated[str, Form()] = "1d6",
+    hit_dice: Annotated[int, Form()] = 1,
+    weapon_range: Annotated[int, Form()] = 0,
+    description: Annotated[str, Form()] = "",
+    notes: Annotated[str, Form()] = "",
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    result = eng_update_encounter_npc(
+        state, UUID(group_id), UUID(npc_id), name, description, hp_max,
+        defense, notes, hit_dice, resistance, weapon_range, damage_dice,
+    )
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/encounter_roster/{group_id}/npc/{npc_id}/delete", response_class=HTMLResponse)
+async def route_encounter_npc_delete(channel_id: str, group_id: str, npc_id: str):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    result = eng_remove_encounter_npc(state, UUID(group_id), UUID(npc_id))
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
 
 
 # ---------------------------------------------------------------------------

--- a/webui/app.py
+++ b/webui/app.py
@@ -46,6 +46,7 @@ from engine import (
     register_room,
     remove_item,
     remove_npc,
+    remove_npc_condition,
     resolve_turn,
     resume_session,
     set_character_hp,
@@ -1070,6 +1071,52 @@ async def route_npc_copy(
     if from_page == "npcs":
         return _respond_npcs(channel_id)
     return _respond(channel_id, view_room_id=view_room_id)
+
+
+# ---------------------------------------------------------------------------
+# NPC condition management (roster editor — no battlefield required)
+# ---------------------------------------------------------------------------
+
+@app.post("/session/{channel_id}/npc/{npc_id}/addcondition", response_class=HTMLResponse)
+async def route_npc_addcondition(
+    channel_id:   str,
+    npc_id:       str,
+    condition_id: Annotated[str, Form()],
+    duration:     Annotated[int, Form()] = 3,
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    try:
+        cid = UUID(npc_id)
+    except ValueError as e:
+        return _respond_npcs(channel_id, error=str(e))
+    dur = None if duration <= 0 else max(1, duration)
+    result = apply_condition(state, cid, condition_id, duration=dur, applied_this_turn=False)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id, flash=result.message)
+
+
+@app.post("/session/{channel_id}/npc/{npc_id}/removecondition", response_class=HTMLResponse)
+async def route_npc_removecondition(
+    channel_id:   str,
+    npc_id:       str,
+    condition_id: Annotated[str, Form()],
+):
+    state = store.get_session(channel_id)
+    if state is None:
+        return HTMLResponse("Session not found.", status_code=404)
+    try:
+        cid = UUID(npc_id)
+    except ValueError as e:
+        return _respond_npcs(channel_id, error=str(e))
+    result = remove_npc_condition(state, cid, condition_id)
+    if not result.ok:
+        return _respond_npcs(channel_id, error=result.error)
+    await save_session_async(state)
+    return _respond_npcs(channel_id)
 
 
 # ---------------------------------------------------------------------------

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -383,7 +383,8 @@ def turn_panel(state: GameState, edit_id: str = "") -> str:
             if not char:
                 continue
             sub = state.latest_submission(cid)
-            sub_text = f'<em>"{sub.action_text}"</em>' if sub else '<span class="muted">—</span>'
+            active_subs = [s for s in turn.submissions if s.character_id == cid and s.is_latest]
+            sub_text = f'<em>"{"; ".join(s.action_text for s in active_subs)}"</em>' if active_subs else '<span class="muted">—</span>'
             unsubmit_btn = ""
             if sub and turn.status == TurnStatus.OPEN:
                 cid_str = str(cid)

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -9,6 +9,7 @@ a `name` attribute matching what the server expects.
 from __future__ import annotations
 
 import html as _html
+from uuid import UUID as _UUID
 
 from engine.azure_constants import XP_THRESHOLDS, RechargePeriod
 from engine.character import CharacterManager
@@ -19,6 +20,7 @@ from models import (
     CharacterStatus,
     DoorState,
     GameState,
+    NPCMovementLogic,
     RangeBand,
     SessionMode,
     TurnStatus,
@@ -194,6 +196,21 @@ def page(title: str, body: str) -> str:
 </html>"""
 
 
+def _tab_bar(channel_id: str, active_tab: str) -> str:
+    """Dashboard / NPC Roster tab bar rendered at the top of each session view."""
+    tabs = [
+        ("dashboard", "Dashboard", f"/session/{channel_id}"),
+        ("npcs", "NPC Roster", f"/session/{channel_id}/npcs"),
+    ]
+    items = ""
+    for key, label, href in tabs:
+        if key == active_tab:
+            items += f'<a href="{href}" style="background:#0f3460;color:#fff;padding:0.4rem 1.1rem;border-radius:4px 4px 0 0;text-decoration:none;border:1px solid #1a4a8a;border-bottom:none">{label}</a>'
+        else:
+            items += f'<a href="{href}" style="padding:0.4rem 1.1rem;border-radius:4px 4px 0 0;text-decoration:none;color:#aaa">{label}</a>'
+    return f'<div style="display:flex;gap:2px;border-bottom:1px solid #0f3460;margin-bottom:1rem">{items}</div>'
+
+
 def _sidebar(channel_id: str | None, sessions: list[tuple[str, str]]) -> str:
     links = ""
     for cid, name in sessions:
@@ -283,6 +300,7 @@ def dashboard_fragment(
 
     return f"""
 <div id="dashboard">
+  {_tab_bar(channel_id, "dashboard")}
   {flash_html}{error_html}
   <div class="grid-2">
     <div>
@@ -1353,39 +1371,419 @@ def npc_panel(
   </td>
 </tr>"""
 
-    add_npc_html = f"""
-<hr class="divider">
-<div class="section-header"><h3>Add NPC</h3></div>
-<form hx-post="/session/{channel_id}/addnpc"
-      hx-target="#dashboard" hx-swap="outerHTML">
-  <input type="hidden" name="view_room_id" value="{view_room_id}">
-  <div class="row">
-    <div><label>Name</label><input type="text" name="name" placeholder="Goblin A"></div>
-    <div><label>HP</label><input type="number" name="hp" value="4" min="1"></div>
-    <div><label>DEF</label><input type="number" name="defense" value="0" min="0"></div>
-    <div><label>RES</label><input type="number" name="resistance" value="0" min="0" style="width:55px"></div>
-  </div>
-  <div class="row">
-    <div><label>Damage</label><input type="text" name="damage_dice" value="1d6" style="width:70px"></div>
-    <div><label>HD</label><input type="number" name="hit_dice" value="1" min="1" style="width:55px"></div>
-    <div><label>Range</label><input type="number" name="weapon_range" value="0" min="0" style="width:55px"></div>
-    <div><label>Description</label><input type="text" name="description" placeholder="Brief description"></div>
-  </div>
-  <label>DM Notes</label>
-  <input type="text" name="notes" placeholder="DM-facing notes">
-  <div class="row" style="margin-top:0.4rem">
-    <label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer">
-      <input type="checkbox" name="hidden" value="true"> Start hidden
-    </label>
-  </div>
-  <button type="submit">Add NPC</button>
-</form>"""
+    roster_link = f'<a href="/session/{channel_id}/npcs" style="font-size:0.82rem;color:#888">Manage full NPC roster &rarr;</a>'
 
     return f"""
 <div class="card">
-  <div class="section-header"><h3>NPCs</h3></div>
+  <div class="section-header">
+    <h3>NPCs in Room</h3>
+    {roster_link}
+  </div>
   {'<table><tr><th>NPC</th><th>HP</th><th>Controls</th></tr>' + rows + '</table>' if rows else '<p class="muted">No NPCs in this room.</p>'}
-  {add_npc_html}
+</div>"""
+
+
+# ---------------------------------------------------------------------------
+# NPC Roster page
+# ---------------------------------------------------------------------------
+
+def npc_roster_page(
+    state: GameState,
+    sessions: list[tuple[str, str]],
+    flash: str = "",
+    error: str = "",
+    edit_id: str = "",
+) -> str:
+    channel_id = state.platform_channel_id
+    body = f"""
+<div class="layout">
+  {_sidebar(channel_id, sessions)}
+  <div class="main">
+    {npc_roster_fragment(state, flash, error, edit_id)}
+  </div>
+</div>"""
+    return page("NPC Roster — DM Panel", body)
+
+
+def npc_roster_fragment(
+    state: GameState,
+    flash: str = "",
+    error: str = "",
+    edit_id: str = "",
+) -> str:
+    channel_id = state.platform_channel_id
+    flash_html = f'<div class="flash">{flash}</div>' if flash else ""
+    error_html = f'<div class="error">{error}</div>' if error else ""
+    return f"""
+<div id="npc-roster">
+  {_tab_bar(channel_id, "npcs")}
+  {flash_html}{error_html}
+  {_npc_groups_section(state, channel_id, edit_id)}
+  {_encounter_settings_section(state, channel_id)}
+  {_encounter_roster_section(state, channel_id, edit_id)}
+</div>"""
+
+
+def _npc_groups_section(state: GameState, channel_id: str, edit_id: str) -> str:
+    groups = list(state.npc_roster.groups.values())
+
+    room_name_map: dict[str, str] = {}
+    if state.dungeon:
+        for rid, room in state.dungeon.rooms.items():
+            room_name_map[str(rid)] = room.name
+
+    cards = ""
+    for group in groups:
+        gid = str(group.group_id)
+        room_name = room_name_map.get(str(group.current_room_id), "—") if group.current_room_id else "—"
+        logic_label = group.movement_logic.value.capitalize() if group.movement_logic else "Stationary"
+        group_display_name = _html.escape(group.name or "(unnamed group)")
+        npc_count = len(group.npcs)
+
+        if edit_id == f"group:{gid}":
+            _e_gname = _html.escape(group.name or "", quote=True)
+            logic_options = "".join(
+                f'<option value="{m.value}" {"selected" if group.movement_logic == m else ""}>{m.value.capitalize()}</option>'
+                for m in NPCMovementLogic
+            )
+            room_options = '<option value="">— None —</option>' + "".join(
+                f'<option value="{rid}" {"selected" if str(group.current_room_id) == rid else ""}>{_html.escape(rname)}</option>'
+                for rid, rname in sorted(room_name_map.items(), key=lambda x: x[1])
+            )
+            possible_checkboxes = "".join(
+                f'<label style="display:flex;align-items:center;gap:0.4rem;font-size:0.82rem;margin-top:2px"><input type="checkbox" name="possible_rooms" value="{rid}" {"checked" if _UUID(rid) in group.possible_rooms else ""}> {_html.escape(rname)}</label>'
+                for rid, rname in sorted(room_name_map.items(), key=lambda x: x[1])
+            )
+            group_header = f"""
+<form hx-post="/session/{channel_id}/group/{gid}/update"
+      hx-target="#npc-roster" hx-swap="outerHTML">
+  <div class="row">
+    <div><label>Group Name</label><input type="text" name="name" value="{_e_gname}" placeholder="(optional)"></div>
+    <div style="flex:0;min-width:130px"><label>Movement</label>
+    <select name="movement_logic">{logic_options}</select></div>
+    <div style="flex:0;min-width:160px"><label>Current Room</label>
+    <select name="current_room_id">{room_options}</select></div>
+  </div>
+  <details style="margin-top:0.5rem"><summary style="cursor:pointer;font-size:0.82rem;color:#aaa">Possible rooms</summary>
+  <div style="margin-top:0.3rem">{possible_checkboxes or "<span class='muted'>No rooms in dungeon.</span>"}</div>
+  </details>
+  <div class="row" style="margin-top:0.5rem">
+    <button type="submit">Save Group</button>
+    <a href="/session/{channel_id}/npcs" style="align-self:center;font-size:0.85rem;color:#888">cancel</a>
+  </div>
+</form>"""
+        else:
+            group_header = f"""
+<div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap">
+  <strong>{group_display_name}</strong>
+  <span class="muted" style="font-size:0.8rem">{logic_label} &bull; {room_name} &bull; {npc_count} NPC(s)</span>
+  <a href="/session/{channel_id}/npcs?edit=group:{gid}" class="btn-sm">Edit Group</a>
+  <form style="display:inline" hx-post="/session/{channel_id}/group/{gid}/delete"
+        hx-target="#npc-roster" hx-swap="outerHTML"
+        hx-confirm="Delete group '{group.name or 'unnamed'}' and all its NPCs?">
+    <button class="btn-sm btn-danger" type="submit">Delete Group</button>
+  </form>
+</div>"""
+
+        npc_rows = ""
+        for npc in group.npcs:
+            nid = str(npc.npc_id)
+            _e_nname = _html.escape(npc.name)
+            _e_ndesc = _html.escape(npc.description or "")
+            if edit_id == f"npc:{nid}":
+                _eq_name = _html.escape(npc.name, quote=True)
+                _eq_desc = _html.escape(npc.description or "", quote=True)
+                _eq_notes = _html.escape(npc.notes or "", quote=True)
+                _eq_dmg = _html.escape(npc.damage_dice or "1d6", quote=True)
+                npc_rows += f"""
+<tr>
+  <td colspan="8">
+    <form hx-post="/session/{channel_id}/npc/{nid}/update"
+          hx-target="#npc-roster" hx-swap="outerHTML">
+      <input type="hidden" name="from_page" value="npcs">
+      <div class="row">
+        <div><label>Name</label><input type="text" name="name" value="{_eq_name}" required></div>
+        <div><label>HP Max</label><input type="number" name="hp_max" value="{npc.hp_max}" min="1" style="width:60px"></div>
+        <div><label>HP Now</label><input type="number" name="hp_current" value="{npc.hp_current}" min="0" style="width:60px"></div>
+        <div><label>DEF</label><input type="number" name="defense" value="{npc.defense}" min="0" style="width:55px"></div>
+        <div><label>RES</label><input type="number" name="resistance" value="{npc.resistance}" min="0" style="width:55px"></div>
+        <div><label>HD</label><input type="number" name="hit_dice" value="{npc.hit_dice}" min="1" style="width:55px"></div>
+        <div><label>Range</label><input type="number" name="weapon_range" value="{npc.weapon_range}" min="0" style="width:55px"></div>
+        <div><label>Damage</label><input type="text" name="damage_dice" value="{_eq_dmg}" style="width:70px"></div>
+      </div>
+      <div class="row">
+        <div><label>Description</label><input type="text" name="description" value="{_eq_desc}"></div>
+        <div><label>Notes</label><input type="text" name="notes" value="{_eq_notes}"></div>
+      </div>
+      <div class="row" style="margin-top:0.5rem">
+        <button type="submit">Save NPC</button>
+        <a href="/session/{channel_id}/npcs" style="align-self:center;font-size:0.85rem;color:#888">cancel</a>
+      </div>
+    </form>
+  </td>
+</tr>"""
+            else:
+                npc_rows += f"""
+<tr>
+  <td><strong>{_e_nname}</strong><br><span class="muted">{_e_ndesc}</span></td>
+  <td class="hp-bar">{npc.hp_current}/{npc.hp_max}</td>
+  <td>{npc.defense}</td>
+  <td>{npc.resistance}</td>
+  <td>{npc.damage_dice}</td>
+  <td>{npc.hit_dice}</td>
+  <td>{npc.weapon_range}</td>
+  <td style="white-space:nowrap">
+    <a href="/session/{channel_id}/npcs?edit=npc:{nid}" class="btn-sm">Edit</a>
+    <form style="display:inline" hx-post="/session/{channel_id}/npc/{nid}/copy"
+          hx-target="#npc-roster" hx-swap="outerHTML">
+      <input type="hidden" name="from_page" value="npcs">
+      <button class="btn-sm" type="submit">Copy</button>
+    </form>
+    <form style="display:inline" hx-post="/session/{channel_id}/npc/{nid}/delete"
+          hx-target="#npc-roster" hx-swap="outerHTML"
+          hx-confirm="Remove {_html.escape(npc.name, quote=True)}?">
+      <input type="hidden" name="from_page" value="npcs">
+      <button class="btn-sm btn-danger" type="submit">Del</button>
+    </form>
+  </td>
+</tr>"""
+
+        npc_table = f"""
+<table style="margin-top:0.5rem;font-size:0.85rem">
+  <tr><th>NPC</th><th>HP</th><th>DEF</th><th>RES</th><th>DMG</th><th>HD</th><th>Rng</th><th>Actions</th></tr>
+  {npc_rows}
+</table>""" if npc_rows else '<p class="muted" style="font-size:0.85rem;margin-top:0.5rem">No NPCs in this group.</p>'
+
+        add_npc_form = f"""
+<details style="margin-top:0.5rem"><summary style="cursor:pointer;font-size:0.82rem;color:#aaa">+ Add NPC to group</summary>
+<form hx-post="/session/{channel_id}/group/{gid}/addnpc"
+      hx-target="#npc-roster" hx-swap="outerHTML" style="margin-top:0.5rem">
+  <div class="row">
+    <div><label>Name</label><input type="text" name="name" placeholder="Goblin A" required></div>
+    <div><label>HP</label><input type="number" name="hp" value="4" min="1" style="width:65px"></div>
+    <div><label>DEF</label><input type="number" name="defense" value="0" min="0" style="width:55px"></div>
+    <div><label>RES</label><input type="number" name="resistance" value="0" min="0" style="width:55px"></div>
+    <div><label>Damage</label><input type="text" name="damage_dice" value="1d6" style="width:70px"></div>
+    <div><label>HD</label><input type="number" name="hit_dice" value="1" min="1" style="width:55px"></div>
+    <div><label>Range</label><input type="number" name="weapon_range" value="0" min="0" style="width:55px"></div>
+  </div>
+  <div><label>Description</label><input type="text" name="description" placeholder="Brief description"></div>
+  <button type="submit" style="margin-top:0.4rem">Add NPC</button>
+</form>
+</details>"""
+
+        promote_form = f"""
+<form style="display:inline" hx-post="/session/{channel_id}/group/{gid}/promote_encounter"
+      hx-target="#npc-roster" hx-swap="outerHTML" style="margin-top:0.3rem">
+  <input type="number" name="weight" value="1" min="1" style="width:50px;display:inline;padding:2px 4px">
+  <button class="btn-sm" type="submit" title="Add a copy of this group to the random encounter roster">+ Encounter Roster</button>
+</form>"""
+
+        cards += f"""
+<div class="card" style="margin-bottom:0.75rem">
+  {group_header}
+  {npc_table}
+  {add_npc_form}
+  <div style="margin-top:0.5rem;padding-top:0.5rem;border-top:1px solid #0f3460;font-size:0.82rem;color:#888">
+    Add to encounter roster with weight: {promote_form}
+  </div>
+</div>"""
+
+    new_group_form = f"""
+<div class="card">
+  <div class="section-header"><h3 style="font-size:0.95rem">Create New Group</h3></div>
+  <form hx-post="/session/{channel_id}/addgroup"
+        hx-target="#npc-roster" hx-swap="outerHTML">
+    <div class="row">
+      <div><label>Group Name (optional)</label><input type="text" name="group_name" placeholder="e.g. Goblin Patrol"></div>
+      <div style="flex:0;min-width:130px"><label>Movement</label>
+      <select name="movement_logic">
+        {''.join(f'<option value="{m.value}">{m.value.capitalize()}</option>' for m in NPCMovementLogic)}
+      </select></div>
+    </div>
+    <hr class="divider" style="margin:0.5rem 0">
+    <p style="font-size:0.82rem;color:#aaa;margin:0 0 0.4rem">First NPC (required):</p>
+    <div class="row">
+      <div><label>Name</label><input type="text" name="name" placeholder="Goblin A" required></div>
+      <div><label>HP</label><input type="number" name="hp" value="4" min="1" style="width:65px"></div>
+      <div><label>DEF</label><input type="number" name="defense" value="0" min="0" style="width:55px"></div>
+      <div><label>RES</label><input type="number" name="resistance" value="0" min="0" style="width:55px"></div>
+      <div><label>Damage</label><input type="text" name="damage_dice" value="1d6" style="width:70px"></div>
+      <div><label>HD</label><input type="number" name="hit_dice" value="1" min="1" style="width:55px"></div>
+      <div><label>Range</label><input type="number" name="weapon_range" value="0" min="0" style="width:55px"></div>
+    </div>
+    <div><label>Description</label><input type="text" name="description" placeholder="Brief description"></div>
+    <button type="submit" style="margin-top:0.5rem">Create Group</button>
+  </form>
+</div>"""
+
+    no_groups_html = '<div class="card"><p class="muted">No NPC groups in the dungeon yet.</p></div>' if not cards else ""
+    return f"""
+<h3 style="color:#c9a84c;margin-bottom:0.5rem">NPC Groups</h3>
+{no_groups_html}
+{cards}
+{new_group_form}"""
+
+
+def _encounter_settings_section(state: GameState, channel_id: str) -> str:
+    if not state.dungeon:
+        return ""
+    dungeon = state.dungeon
+    _e_roll = _html.escape(dungeon.random_encounter_roll or "1d6", quote=True)
+    return f"""
+<div class="card">
+  <div class="section-header"><h3>Random Encounter Settings</h3></div>
+  <form hx-post="/session/{channel_id}/dungeon/update"
+        hx-target="#npc-roster" hx-swap="outerHTML">
+    <input type="hidden" name="name" value="{_html.escape(dungeon.name, quote=True)}">
+    <input type="hidden" name="description" value="{_html.escape(dungeon.description or '', quote=True)}">
+    <input type="hidden" name="from_page" value="npcs">
+    <div class="row">
+      <div><label>Check every N turns</label>
+      <input type="number" name="random_encounter_interval" value="{dungeon.random_encounter_interval}" min="1" style="width:80px"></div>
+      <div><label>Roll expression</label>
+      <input type="text" name="random_encounter_roll" value="{_e_roll}" style="width:80px"></div>
+    </div>
+    <p class="muted" style="margin:0.3rem 0 0.5rem">Encounter fires when roll &le; 1 (modified by room hazard). Roll checked after every N turns.</p>
+    <button type="submit">Save Settings</button>
+  </form>
+</div>"""
+
+
+def _encounter_roster_section(state: GameState, channel_id: str, edit_id: str) -> str:
+    if not state.dungeon:
+        return ""
+    roster = state.dungeon.random_encounter_roster
+
+    rows = ""
+    for entry in roster:
+        eg = entry.npc_group
+        egid = str(eg.group_id)
+        group_display = _html.escape(eg.name or "(unnamed)")
+        npc_count = len(eg.npcs)
+
+        npc_detail_rows = ""
+        for npc in eg.npcs:
+            nid = str(npc.npc_id)
+            _e_nname = _html.escape(npc.name)
+            if edit_id == f"enc_npc:{nid}":
+                _eq_name = _html.escape(npc.name, quote=True)
+                _eq_desc = _html.escape(npc.description or "", quote=True)
+                _eq_dmg = _html.escape(npc.damage_dice or "1d6", quote=True)
+                npc_detail_rows += f"""
+<tr>
+  <td colspan="7">
+    <form hx-post="/session/{channel_id}/encounter_roster/{egid}/npc/{nid}/update"
+          hx-target="#npc-roster" hx-swap="outerHTML">
+      <div class="row">
+        <div><label>Name</label><input type="text" name="name" value="{_eq_name}" required></div>
+        <div><label>HP</label><input type="number" name="hp_max" value="{npc.hp_max}" min="1" style="width:60px"></div>
+        <div><label>DEF</label><input type="number" name="defense" value="{npc.defense}" min="0" style="width:55px"></div>
+        <div><label>RES</label><input type="number" name="resistance" value="{npc.resistance}" min="0" style="width:55px"></div>
+        <div><label>HD</label><input type="number" name="hit_dice" value="{npc.hit_dice}" min="1" style="width:55px"></div>
+        <div><label>Range</label><input type="number" name="weapon_range" value="{npc.weapon_range}" min="0" style="width:55px"></div>
+        <div><label>Damage</label><input type="text" name="damage_dice" value="{_eq_dmg}" style="width:70px"></div>
+      </div>
+      <div><label>Description</label><input type="text" name="description" value="{_eq_desc}"></div>
+      <div class="row" style="margin-top:0.4rem">
+        <button type="submit">Save</button>
+        <a href="/session/{channel_id}/npcs" style="align-self:center;font-size:0.85rem;color:#888">cancel</a>
+      </div>
+    </form>
+  </td>
+</tr>"""
+            else:
+                npc_detail_rows += f"""
+<tr>
+  <td><strong>{_e_nname}</strong></td>
+  <td>{npc.hp_max}</td>
+  <td>{npc.defense}</td>
+  <td>{npc.resistance}</td>
+  <td>{npc.hit_dice}</td>
+  <td>{npc.weapon_range}</td>
+  <td style="white-space:nowrap">
+    <a href="/session/{channel_id}/npcs?edit=enc_npc:{nid}" class="btn-sm">Edit</a>
+    <form style="display:inline" hx-post="/session/{channel_id}/encounter_roster/{egid}/npc/{nid}/delete"
+          hx-target="#npc-roster" hx-swap="outerHTML"
+          hx-confirm="Remove {_html.escape(npc.name, quote=True)} from template?">
+      <button class="btn-sm btn-danger" type="submit">Del</button>
+    </form>
+  </td>
+</tr>"""
+
+        npc_subtable = f"""
+<table style="font-size:0.82rem;margin-left:1rem;margin-top:0.3rem">
+  <tr><th>NPC</th><th>HP</th><th>DEF</th><th>RES</th><th>HD</th><th>Rng</th><th>Actions</th></tr>
+  {npc_detail_rows}
+</table>"""
+
+        add_to_entry_form = f"""
+<details style="margin-left:1rem;margin-top:0.3rem"><summary style="cursor:pointer;font-size:0.8rem;color:#aaa">+ Add NPC to template</summary>
+<form hx-post="/session/{channel_id}/encounter_roster/{egid}/addnpc"
+      hx-target="#npc-roster" hx-swap="outerHTML" style="margin-top:0.4rem">
+  <div class="row">
+    <div><label>Name</label><input type="text" name="name" placeholder="Goblin A" required></div>
+    <div><label>HP</label><input type="number" name="hp" value="4" min="1" style="width:65px"></div>
+    <div><label>DEF</label><input type="number" name="defense" value="0" min="0" style="width:55px"></div>
+    <div><label>Damage</label><input type="text" name="damage_dice" value="1d6" style="width:70px"></div>
+    <div><label>HD</label><input type="number" name="hit_dice" value="1" min="1" style="width:55px"></div>
+  </div>
+  <button type="submit" style="margin-top:0.3rem">Add NPC</button>
+</form></details>"""
+
+        rows += f"""
+<div style="border:1px solid #0f3460;border-radius:6px;padding:0.75rem;margin-bottom:0.5rem">
+  <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap">
+    <strong>{group_display}</strong>
+    <span class="muted" style="font-size:0.8rem">{npc_count} NPC(s)</span>
+    <form style="display:inline;display:flex;gap:0.3rem;align-items:center"
+          hx-post="/session/{channel_id}/encounter_roster/{egid}/update_weight"
+          hx-target="#npc-roster" hx-swap="outerHTML">
+      <label style="margin:0;font-size:0.8rem;color:#aaa">Weight:</label>
+      <input type="number" name="weight" value="{entry.weight}" min="1" style="width:55px;display:inline;padding:2px 4px">
+      <button class="btn-sm" type="submit">Set</button>
+    </form>
+    <form style="display:inline" hx-post="/session/{channel_id}/encounter_roster/{egid}/delete"
+          hx-target="#npc-roster" hx-swap="outerHTML"
+          hx-confirm="Remove '{_html.escape(eg.name or 'unnamed', quote=True)}' from encounter roster?">
+      <button class="btn-sm btn-danger" type="submit">Remove</button>
+    </form>
+  </div>
+  {npc_subtable}
+  {add_to_entry_form}
+</div>"""
+
+    add_entry_form = f"""
+<hr class="divider">
+<div class="section-header"><h3 style="font-size:0.95rem">Add New Encounter Entry</h3></div>
+<form hx-post="/session/{channel_id}/encounter_roster/add"
+      hx-target="#npc-roster" hx-swap="outerHTML">
+  <div class="row">
+    <div><label>Group Name (optional)</label><input type="text" name="group_name" placeholder="e.g. Goblin Patrol"></div>
+    <div style="flex:0;min-width:80px"><label>Weight</label><input type="number" name="weight" value="1" min="1" style="width:65px"></div>
+  </div>
+  <p style="font-size:0.82rem;color:#aaa;margin:0.4rem 0">First template NPC:</p>
+  <div class="row">
+    <div><label>Name</label><input type="text" name="name" placeholder="Goblin A" required></div>
+    <div><label>HP</label><input type="number" name="hp" value="4" min="1" style="width:65px"></div>
+    <div><label>DEF</label><input type="number" name="defense" value="0" min="0" style="width:55px"></div>
+    <div><label>RES</label><input type="number" name="resistance" value="0" min="0" style="width:55px"></div>
+    <div><label>Damage</label><input type="text" name="damage_dice" value="1d6" style="width:70px"></div>
+    <div><label>HD</label><input type="number" name="hit_dice" value="1" min="1" style="width:55px"></div>
+    <div><label>Range</label><input type="number" name="weapon_range" value="0" min="0" style="width:55px"></div>
+  </div>
+  <div><label>Description</label><input type="text" name="description" placeholder="Brief description"></div>
+  <button type="submit" style="margin-top:0.5rem">Add to Encounter Roster</button>
+</form>"""
+
+    entry_count = len(roster)
+    return f"""
+<div class="card">
+  <div class="section-header"><h3>Random Encounter Roster</h3>
+    <span class="muted" style="font-size:0.85rem">{entry_count} entr{'y' if entry_count == 1 else 'ies'}</span>
+  </div>
+  {rows or '<p class="muted">No encounter entries yet.</p>'}
+  {add_entry_form}
 </div>"""
 
 

--- a/webui/templates.py
+++ b/webui/templates.py
@@ -1425,6 +1425,51 @@ def npc_roster_fragment(
 </div>"""
 
 
+def _npc_conditions_editor(npc, channel_id: str, nid: str) -> str:
+    from engine.data_loader import CONDITION_REGISTRY
+
+    chips = ""
+    for cond in npc.active_conditions:
+        cond_def = CONDITION_REGISTRY.get(cond.condition_id)
+        label = cond_def.label if cond_def else cond.condition_id
+        dur_label = f" ({cond.duration_rounds}r)" if cond.duration_rounds is not None else " (∞)"
+        chips += f"""<span class="tag tag-condition" style="margin-right:4px;margin-bottom:4px">
+  {_html.escape(label)}{dur_label}
+  <form style="display:inline"
+        hx-post="/session/{channel_id}/npc/{nid}/removecondition"
+        hx-target="#npc-roster" hx-swap="outerHTML">
+    <input type="hidden" name="condition_id" value="{_html.escape(cond.condition_id, quote=True)}">
+    <button type="submit" style="background:none;border:none;color:#64b5f6;cursor:pointer;padding:0 2px;margin:0;font-size:0.8rem;line-height:1" title="Remove condition">×</button>
+  </form>
+</span>"""
+
+    conditions_display = chips if chips else '<span class="muted" style="font-size:0.78rem">No starting conditions.</span>'
+
+    all_conditions = sorted(CONDITION_REGISTRY.keys())
+    cond_options = "".join(
+        f'<option value="{cid}">{_html.escape(CONDITION_REGISTRY[cid].label)}</option>'
+        for cid in all_conditions
+    )
+
+    return f"""<div style="margin-top:0.6rem;padding-top:0.5rem;border-top:1px solid #0f3460">
+  <label style="font-size:0.78rem;color:#aaa;display:block;margin-bottom:4px">Starting Conditions</label>
+  <div style="margin-bottom:6px">{conditions_display}</div>
+  <form hx-post="/session/{channel_id}/npc/{nid}/addcondition"
+        hx-target="#npc-roster" hx-swap="outerHTML"
+        style="display:flex;gap:6px;align-items:flex-end;flex-wrap:wrap">
+    <div>
+      <label style="font-size:0.78rem">Condition</label>
+      <select name="condition_id" style="font-size:0.78rem">{cond_options}</select>
+    </div>
+    <div>
+      <label style="font-size:0.78rem">Rounds (0=∞)</label>
+      <input type="number" name="duration" value="3" min="0" style="font-size:0.78rem;padding:2px 4px;width:60px">
+    </div>
+    <button class="btn-sm" type="submit">Add</button>
+  </form>
+</div>"""
+
+
 def _npc_groups_section(state: GameState, channel_id: str, edit_id: str) -> str:
     groups = list(state.npc_roster.groups.values())
 
@@ -1521,12 +1566,17 @@ def _npc_groups_section(state: GameState, channel_id: str, edit_id: str) -> str:
         <a href="/session/{channel_id}/npcs" style="align-self:center;font-size:0.85rem;color:#888">cancel</a>
       </div>
     </form>
+    {_npc_conditions_editor(npc, channel_id, nid)}
   </td>
 </tr>"""
             else:
+                _cond_badge = (
+                    f' <span class="tag tag-condition" style="font-size:0.7rem">{len(npc.active_conditions)} cond.</span>'
+                    if npc.active_conditions else ""
+                )
                 npc_rows += f"""
 <tr>
-  <td><strong>{_e_nname}</strong><br><span class="muted">{_e_ndesc}</span></td>
+  <td><strong>{_e_nname}</strong>{_cond_badge}<br><span class="muted">{_e_ndesc}</span></td>
   <td class="hp-bar">{npc.hp_current}/{npc.hp_max}</td>
   <td>{npc.defense}</td>
   <td>{npc.resistance}</td>


### PR DESCRIPTION
Resolves #154. New tab in session view dedicated to editing NPCs. Allows viewing/editing of all NPC groups in the dungeon. Groups may be copied to random encounter table, or new groups may be generated in the random encounter table and edited in place. New NPCManager methods added to accomodate paths in webui. Existing NPC form in session view slimmed down.